### PR TITLE
Clarify testing details for MeshCore setup

### DIFF
--- a/docs/Node-Builds/yellowcooln_meshadv_mc_node_rpi.md
+++ b/docs/Node-Builds/yellowcooln_meshadv_mc_node_rpi.md
@@ -1,6 +1,6 @@
 # MeshCore Raspberry Pi 1W Repeater
 
-This document outlines the bill of materials (BOM) and setup for a MeshCore repeater using a Raspberry Pi and a MeshADV board or similar SX1262 radio. *(Only tested with MeshADV.)*
+This document outlines the bill of materials (BOM) and setup for a MeshCore repeater using a Raspberry Pi and a MeshADV board or similar SX1262 radio. **Tested with MeshADV and PiMesh-1W**
 
 ---
 
@@ -12,6 +12,7 @@ This document outlines the bill of materials (BOM) and setup for a MeshCore repe
 | U.FL to N-Type Female | 1 | $9 | [Amazon](https://www.amazon.com/dp/B0C8M77ZMW) | Connects the MeshADV to the antenna. |
 | ATGM336H GPS+BDS | 1 | $20 | [Amazon](https://www.amazon.com/dp/B09LQDG1HY) | Optional, if you want to build an NTP server as well. |
 | MeshAdv Pi Hat v1.1 | 1 | $? | [Etsy](https://www.etsy.com/listing/1849074257/meshadv-pi-hat-v11-fully-assembled-1) | Currently sold out at the time of writing. PCB is available on [GitHub](https://github.com/chrismyers2000/MeshAdv-Pi-Hat/tree/main/V1.1/IPEX/PCB) to order through [JLCPCB](https://jlcpcb.com/). |
+| PiMesh-1W | 1 | $65-$105 | [MeshSmith](https://meshsmith.net/) | Replacement to MeshADV. Locally made by a local CT Dev. |
 | Raspberry Pi 4B – 2GB | 1 | $45 | [PiShop](https://www.pishop.us/product/raspberry-pi-4-model-b-2gb/) | 2GB is more than enough for MeshCore and leaves resources for other services. |
 | 32GB MicroSD Card | 1 | $14 | [Amazon](https://www.amazon.com/dp/B084CJLNM4) | Max Endurance MicroSD recommended for long runtime. |
 | WaveShare PoE Hat | 1 | $25 | [Amazon](https://www.amazon.com/dp/B0928ZD7QQ) | Optional PoE hat with GPIO passthrough. Note: the fan on these models tends to fail — alternative hats recommended for long-term builds. |

--- a/docs/Node-Builds/yellowcooln_meshadv_mc_node_rpi.md
+++ b/docs/Node-Builds/yellowcooln_meshadv_mc_node_rpi.md
@@ -12,7 +12,7 @@ This document outlines the bill of materials (BOM) and setup for a MeshCore repe
 | U.FL to N-Type Female | 1 | $9 | [Amazon](https://www.amazon.com/dp/B0C8M77ZMW) | Connects the MeshADV to the antenna. |
 | ATGM336H GPS+BDS | 1 | $20 | [Amazon](https://www.amazon.com/dp/B09LQDG1HY) | Optional, if you want to build an NTP server as well. |
 | MeshAdv Pi Hat v1.1 | 1 | $? | [Etsy](https://www.etsy.com/listing/1849074257/meshadv-pi-hat-v11-fully-assembled-1) | Currently sold out at the time of writing. PCB is available on [GitHub](https://github.com/chrismyers2000/MeshAdv-Pi-Hat/tree/main/V1.1/IPEX/PCB) to order through [JLCPCB](https://jlcpcb.com/). |
-| PiMesh-1W | 1 | $65-$105 | [MeshSmith](https://meshsmith.net/) | Replacement to MeshADV. Locally made by a local CT Dev. |
+| PiMesh-1W | 1 | $65-$105 | [MeshSmith](https://meshsmith.net/) | Replacement to MeshADV. Made by a local CT Dev. |
 | Raspberry Pi 4B – 2GB | 1 | $45 | [PiShop](https://www.pishop.us/product/raspberry-pi-4-model-b-2gb/) | 2GB is more than enough for MeshCore and leaves resources for other services. |
 | 32GB MicroSD Card | 1 | $14 | [Amazon](https://www.amazon.com/dp/B084CJLNM4) | Max Endurance MicroSD recommended for long runtime. |
 | WaveShare PoE Hat | 1 | $25 | [Amazon](https://www.amazon.com/dp/B0928ZD7QQ) | Optional PoE hat with GPIO passthrough. Note: the fan on these models tends to fail — alternative hats recommended for long-term builds. |


### PR DESCRIPTION
Updated the document to specify that the setup has been tested with both MeshADV and PiMesh-1W.