### PR TITLE
Add “Host a Node” Page for Outreach and New Site Partners

### DIFF
--- a/docs/host-a-node.md
+++ b/docs/host-a-node.md
@@ -127,6 +127,8 @@ MeshCore and Meshtastic use licensed or lightly-licensed spectrum that is compat
 No.  
 Hosting a node does not require a ham radio license or any special certification.
 
+**However:** if you plan to run above **1W transmit power**, you do need to make sure you’re operating under the proper licensing/authorization for your region (for example, ham radio rules where applicable), because higher power can move you out of “license-free” territory.
+
 ---
 
 ### **Can the community help with installation?**

--- a/docs/host-a-node.md
+++ b/docs/host-a-node.md
@@ -1,0 +1,142 @@
+---
+title: Hosting a Greater Boston Mesh Node
+sidebar_position: 7
+description: Learn how to host a MeshCore or Meshtastic node and help expand resilient, community-powered communication across Massachusetts.
+---
+
+# Hosting a Greater Boston Mesh Node
+
+The **Greater Boston Mesh** is a volunteer-led community building a resilient, off-grid communication network across **Massachusetts and the surrounding region**. While we began in the Boston area, our network now spans cities, towns, schools, homes, and rural communities throughout the state.
+
+Our mission is simple: **create a decentralized communication system that continues operating even when traditional infrastructure fails.** Hosting a node is one of the most impactful ways you can help your community.
+
+---
+
+## What is this technology all about?
+
+Modern communication relies on infrastructure that can fail: cell towers, internet providers, fiber backbones, cloud platforms, and commercial data centers.
+
+A mesh network is different:  
+it uses small, low-power radios that connect **directly to each other**, forming a distributed network that continues to function during:
+
+- power outages  
+- natural disasters  
+- fiber/cell backhaul failures  
+- cyber incidents  
+- extreme congestion at large events  
+- rural coverage gaps  
+
+Every new node strengthens the network’s reliability for the entire region.
+
+---
+
+## What you need to know
+
+Greater Boston Mesh supports two complementary technologies:
+
+### **MeshCore**
+- Forms the *long-range statewide backbone*
+- Best for buildings with height or clear lines of sight
+- Perfect for municipalities, emergency ops, public buildings, and commercial sites
+
+### **Meshtastic**
+- Ideal for *local*, neighborhood-level coverage
+- Great for hobbyists, individuals, and community spaces
+- Works alongside MeshCore but serves a different role
+
+You can host **either** or **both**.
+
+If you're unsure which is right for your location, we’ll help you decide.
+
+---
+
+## Ideal hosting locations
+
+Good sites include:
+
+- **Municipal buildings** (DPW, town hall, water towers, public safety buildings)  
+- **Schools, universities, libraries, or campuses**  
+- **Churches, synagogues, mosques, and community centers**  
+- **Commercial buildings with roof access**  
+- **Existing ham / communications towers**  
+- **Private homes on hills or with clear views**  
+
+All you need is:
+
+- a small weatherproof device (hand-sized)  
+- a safe place to mount it  
+- access to standard power  
+
+No special networking, no licensing, and **no internet uplink is required for MeshCore nodes**.
+
+---
+
+## What hosting involves
+
+Hosting is very low effort:
+
+- Installation takes about **10–20 minutes**  
+- Power draw is typically **2–5 watts**  
+- No maintenance is required beyond keeping the device plugged in  
+- We provide guidance or can assist with the setup if needed  
+
+---
+
+## Next steps
+
+If you're interested in hosting a node, please reach out to the person who introduced you to Greater Boston Mesh and share the following information:
+
+- Your **name**
+- The **address or approximate location** where you can host a node
+- Whether you would like us to **provide hardware**
+- Whether you're interested in **MeshCore**, **Meshtastic**, or you're **not sure yet**
+- Any details about roof access, building height, or obstructions (optional)
+
+If you found this page independently or prefer to contact us directly, you can also join our public community Discord:= **https://discord.gg/MUVASVEEES**
+
+A volunteer will follow up to help determine the best option for your location.
+
+---
+
+## Frequently Asked Questions
+
+### **Does this require internet access?**
+No. MeshCore nodes do **not** require internet.  
+Meshtastic nodes can use an internet gateway if available, but it is optional.
+
+---
+
+### **Is it safe for buildings, schools, or public facilities?**
+Yes. The devices are low-power (typically under 1 watt RF) and meet FCC/CE emissions limits.  
+They are passive, non-invasive, and have no access to internal building systems.
+
+---
+
+### **How much power does it use?**
+Around **2–5 watts**, similar to an LED night-light.  
+At Massachusetts electricity rates, that’s roughly **$2–$4 per year**.
+
+---
+
+### **Will this interfere with existing radios?**
+No.  
+MeshCore and Meshtastic use licensed or lightly-licensed spectrum that is compatible with existing public safety, ham, and commercial equipment.
+
+---
+
+### **Do I need a radio license?**
+No.  
+Hosting a node does not require a ham radio license or any special certification.
+
+---
+
+### **Can the community help with installation?**
+Yes — volunteers can assist with site assessment, mounting, configuration, and hardware recommendations.
+
+---
+
+## Want to get more involved?
+
+Explore the rest of this website or join our community spaces to learn more.  
+We’re always excited to welcome new volunteers, building partners, and curious neighbors.
+

--- a/docs/host-a-node.md
+++ b/docs/host-a-node.md
@@ -16,8 +16,7 @@ Our mission is simple: **create a decentralized communication system that contin
 
 Modern communication relies on infrastructure that can fail: cell towers, internet providers, fiber backbones, cloud platforms, and commercial data centers.
 
-A mesh network is different:  
-it uses small, low-power radios that connect **directly to each other**, forming a distributed network that continues to function during:
+A mesh network is different as it uses small, low-power radios that connect **directly to each other**, forming a distributed network that continues to function during:
 
 - power outages  
 - natural disasters  
@@ -65,7 +64,7 @@ All you need is:
 
 - a small weatherproof device (hand-sized)  
 - a safe place to mount it  
-- access to standard power  
+- access to standard power (or install with solar and a battery)
 
 No special networking, no licensing, and **no internet uplink is required for MeshCore nodes**.
 
@@ -92,7 +91,7 @@ If you're interested in hosting a node, please reach out to the person who intro
 - Whether you're interested in **MeshCore**, **Meshtastic**, or you're **not sure yet**
 - Any details about roof access, building height, or obstructions (optional)
 
-If you found this page independently or prefer to contact us directly, you can also join our public community Discord:= **https://discord.gg/MUVASVEEES**
+If you found this page independently or prefer to contact us directly, you can also join our public community Discord: **https://discord.gg/MUVASVEEES**
 
 A volunteer will follow up to help determine the best option for your location.
 


### PR DESCRIPTION
This PR adds a new page, Host a Node, intended to support outreach to individuals and organizations who may be able to host MeshCore or Meshtastic nodes. The goal is to make it easy to share a single, non-technical page that explains the value of hosting a node, what’s involved, and how to take the next steps.

What’s included:
 * Overview of Greater Boston Mesh and the purpose of the network
 * Explanation of MeshCore and Meshtastic roles
 * Ideal hosting locations (schools, municipalities, tower owners, etc.)
 * Hosting requirements and expected power use
 * A next-steps section with clear instructions on how to contact the team
 * A beginner-friendly FAQ to address common questions

Why this is useful:
The network is expanding quickly, and outreach often requires sending background information to people who aren’t familiar with mesh networking. This page provides a central, easy-to-share resource for prospective hosting sites.

Future improvement (optional):
If the maintainers prefer, I can convert the “Next steps” section into a simple web form that delivers submissions to an email address, a Google spreadsheet or a Discord channel (via webhook). Just let me know the preferred approach.

I’m still new to the project, so please feel free to suggest edits, restructuring, or a different placement for the page. Happy to iterate!