### PR TITLE
Improve MeshCore Getting Started with verification guidance and mesh conventions

### DIFF
--- a/docs/MeshCore/meshcore-getting-started.md
+++ b/docs/MeshCore/meshcore-getting-started.md
@@ -7,11 +7,13 @@ sidebar_label: MeshCore Getting Started
 # MeshCore Getting Started  
 *Greater Boston Mesh*
 
-MeshCore is the software used by Greater Boston Mesh to build a decentralized, long-range wireless messaging network using LoRa radios. Nodes communicate directly with each other, forming a mesh that does not rely on the internet or cellular service.
+MeshCore is the software used by Greater Boston Mesh to build a decentralized, [long-range wireless (LoRa)](https://www.semtech.com/lora/what-is-lora) messaging network using LoRa radios. Nodes communicate directly with each other, forming a mesh that does not rely on the internet or cellular service. 
 
 This page is intended to help you get oriented, understand your options, and figure out what to do next — without requiring deep radio or networking knowledge.
 
 If you are interested in hosting infrastructure for the network without getting deeply involved, you may also want to read [Host a Node](https://bostonme.sh/docs/host-a-node).
+
+If you are want to learn more about MeshCore in general please visit [MeshCore.co.uk](https://meshcore.co.uk/about.html).
 
 ---
 
@@ -90,6 +92,20 @@ If you’re just getting started, you can skip room servers entirely. Most peopl
 
 ---
 
+## Encryption and visibility
+
+[MeshCore traffic is encrypted](https://meshcore.co.uk/about.html). However:
+
+- Public channels are shared keys, meaning anyone with that channel key can read those messages
+- Message routing metadata (the path a message took through the mesh) is visible to the network
+- Even if you hide your GPS location, traffic patterns and repeater paths are not private
+
+If you require private communication, use private channels with shared keys rather than public ones. If you publicly share your shared keys then it is no longer private.
+
+In short: encrypted does not mean anonymous.
+
+---
+
 ## What you need to get started
 
 At a minimum:
@@ -119,57 +135,76 @@ If you are running a companion node in a fixed location or planning to host a re
 
 ## Flashing and initial setup
 
-When you’re ready to set up your LoRa radio, the first step is loading **MeshCore firmware** onto the device using [the official MeshCore web flasher](https://flasher.meshcore.co.uk).
+When you’re ready to set up your LoRa radio, the first step is loading **MeshCore firmware** onto the device using the official MeshCore web flasher:
+
+[MeshCore Web Flasher](https://flasher.meshcore.co.uk)
 
 Typical first-time steps:
-1. Connect your device to your computer via USB
-2. Open the MeshCore web flasher
-3. Select your device (or the detected port)
-4. Choose a role (Companion USB/BLE, Repeater, Room Server)
-5. Flash the firmware
 
-When flashing finishes, **power-cycle or restart** the radio. It should boot up running the firmware you just installed.
+1. Connect your device to your computer via USB  
+2. Open the MeshCore web flasher  
+3. Select your device (or detected port)  
+4. Choose a role (Companion USB/BLE, Repeater, Room Server)  
+5. Flash the firmware  
 
-If anything acts weird (not detected, won’t flash, won’t boot), hop into the community [Discord](https://discord.gg/MUVASVEEES) and ask for some help in the MeshCore `#troubleshooting` channel.
+When flashing finishes, **power-cycle or restart** the radio. It should boot running the firmware you just installed.
+
+If anything behaves unexpectedly (not detected, won’t flash, won’t boot, can’t connect), visit the community Discord and ask for help in the MeshCore `#troubleshooting` channel:
+
+[MeshCore Discord](https://discord.gg/MUVASVEEES)
+
+For full firmware documentation and release notes, see: [MeshCore GitHub Repository](https://github.com/meshcore-dev/meshcore)
 
 ---
 
 ## Greater Boston Mesh conventions and guidance
 
-These are **recommendations**, not hard rules. They exist to keep the mesh understandable and healthy.
+### Use the USA/Canada preset
 
-### Node names
+Please use the **USA/Canada preset**.
 
-- Choose a name that is descriptive and reasonably unique
-- Town- or neighborhood-based names are common
-- Avoid extremely short or generic names
+If you change the frequency, bandwidth, or spreading factor, your node will not be able to communicate with the Greater Boston Mesh.
 
-Examples:
-- `BOS - North Station NE`
-- `CMD - Central Sq - 001`
-- `WAT - Arsenal`
+If your node cannot see or reach anyone, double-check that you are using the USA/Canada preset.
+
+MeshCore relies on shared spectrum and shared settings. Especially for repeater setups:
+
+- Use a flood advert interval of **47 hours**
+- More power or more frequent adverts is not always better
+- By default, zero-hop advert is set to `0` (you may optionally set it to something like `240` minutes)
+
+Keeping consistent settings ensures stability and reduces unnecessary RF noise.
 
 ---
 
-### Adverts and airtime
+### Node names
 
-MeshCore relies on shared radio spectrum.
+These are recommendations, not hard rules. They exist to keep the mesh understandable and healthy.
 
-- Use an advert interval of 47 hours
-- Avoid overly aggressive broadcast settings
-- More power or more frequent adverts is not always better
+- Choose a name that is descriptive and reasonably unique  
+- Town- or neighborhood-based names are common  
+- Avoid extremely short or generic names  
 
-If you’re hosting a repeater, this matters more.
+Examples:
+
+- `BOS - North Station NE`  
+- `CMD - Central Sq - 001`  
+- `WAT - Arsenal`  
+
+Clear naming helps with troubleshooting, mapping coverage, and general sanity.
 
 ---
 
 ### MeshCore key prefixes (advanced)
 
-MeshCore uses a short prefix derived from your node’s public key. In rare cases, two nearby nodes may share the same prefix, which can make debugging confusing.
+MeshCore uses a short prefix derived from your node’s public key.
 
-As more people bring repeaters online, avoiding prefix collisions becomes more important, especially in dense areas. Collisions are still uncommon, but they can make troubleshooting and identifying traffic much harder when they do happen.
+In rare cases, two nearby nodes may share the same prefix. When that happens, debugging can become confusing, especially in dense areas with multiple repeaters.
 
-Repeater hosts should read:  
+Collisions are still uncommon, but as more repeaters come online, avoiding prefix collisions becomes more important.
+
+Repeater hosts should read:
+
 [MeshCore key prefix collisions](https://bostonme.sh/docs/MeshCore/meshcore-collisions)
 
 If you’re unsure, ask in Discord before changing anything.
@@ -189,6 +224,61 @@ MeshCore works best when people coordinate, even loosely.
 
 ---
 
+## Verifying your node is working
+
+After flashing and configuring your node, the next question is usually: how do I know it’s actually working?
+
+### Use public channels
+
+You can send messages in the main Public channel, but there are additional public channels such as `#test`.
+
+If you want to send test messages without adding noise to the main Public channel, add and use the `#test` channel instead.
+
+There are often bots running in `#test` that will auto-respond if you send:
+
+- `ackbot`
+- `test`
+
+If you receive a response, that confirms your node is successfully transmitting and receiving at least one hop into the mesh.
+
+---
+
+### Use the Mesh Analyzer
+
+The most reliable way to verify that your node is fully participating in the mesh is to use:
+
+[Mesh Analyzer](https://analyzer.letsmesh.net/channels)
+
+1. Select the `BOS` region
+2. Select the channel you are using (Public, #test, etc.)
+
+You can view:
+
+- Messages as seen by an observer node
+- The path messages took through the mesh
+- Which repeaters handled the traffic
+
+This helps confirm:
+- Your messages are reaching the wider mesh
+- You are receiving messages seen by others
+- The route quality and hop count look reasonable
+
+If your messages appear locally but do not show up in the analyzer, your node may not be reaching a well-connected repeater.
+
+---
+
+### Use built-in tools
+
+Both the mobile app and companion tools provide additional diagnostics:
+
+- **Ping** – Check if another nearby node responds
+- **Trace** – See the signal quality and hop path starting from your companion node
+- **LOS (Line of Sight)** – Evaluate terrain and obstruction between two locations
+
+These tools help diagnose placement issues, antenna problems, or configuration mismatches.
+
+---
+
 ## Still unsure?
 
 That’s normal. MeshCore has a low barrier to entry, and you can start small.
@@ -197,5 +287,7 @@ If you’re not sure where to begin:
 - Start with a client node
 - Leave settings mostly default
 - Ask before making major changes
+
+You may also want to visit the [official MeshCore FAQ](https://github.com/meshcore-dev/MeshCore/blob/main/docs/faq.md)
 
 We’re glad you’re here.

--- a/docs/MeshCore/meshcore-getting-started.md
+++ b/docs/MeshCore/meshcore-getting-started.md
@@ -161,7 +161,7 @@ For full firmware documentation and release notes, see: [MeshCore GitHub Reposit
 
 ### Use the USA/Canada preset
 
-Please use the **USA/Canada preset**.
+Please use the [USA/Canada preset](https://bostonme.sh/meshcore#contact).
 
 If you change the frequency, bandwidth, or spreading factor, your node will not be able to communicate with the Greater Boston Mesh.
 


### PR DESCRIPTION
This PR expands the MeshCore Getting Started page to better support new node operators.

Changes include:
 - Clarified flashing and initial setup steps
 - Explicit guidance to use the USA/Canada preset
 - Added section on how to verify that a node is working
 - Added brief explanation of encryption and public channel visibility

The goal is to reduce common Discord troubleshooting questions and provide a clearer path from “flashed device” to “participating node.”

Follow-up work (for anyone):
 - Draft or find separate Hardware Recommendations guide
 - Draft or find an Antenna and Placement guide

Feedback welcome.