### PR TITLE
Update MeshCore docs and page for MeshMapper transition

### DIFF
--- a/docs/MeshCore/meshcore-mqtt.md
+++ b/docs/MeshCore/meshcore-mqtt.md
@@ -5,24 +5,29 @@ sidebar_label: Meshcore MQTT
 ---
 # MeshCore MQTT Server
 
-Greater Boston Mesh runs its own MQTT server to populate our **[WarDrive Coverage Map](https://coveragemap.bostonme.sh/)** and **[Live Packet Map](https://live.bostonme.sh/)**.
+Greater Boston Mesh runs its own MQTT server to populate our **[MeshMapper Coverage Map](https://bos.meshmapper.net/)** and **[Live Packet Map](https://live.bostonme.sh/)**.
 
 The coverage map requires coverage verification via MQTT, so if you are not connected to the Greater Boston Mesh, you’ll need to connect your node to the MQTT server.
 
-There are two supported push-agent projects. Pick the one that matches how you connect to your node:
+There are three supported push-agent options. Pick the one that matches how you connect to your node:
 
 - [MeshCore-to-MQTT (repeater/roomserver style):](https://github.com/Cisien/meshcoretomqtt)
 - [MeshCore Packet Capture (companion):](https://github.com/agessaman/meshcore-packet-capture)
+- [MeshCore HA Add-on (Home Assistant):](https://meshcore-dev.github.io/meshcore-ha/docs/ha/mqtt)
 
 Use these broker settings:
 
 - **Broker:** `mqttmc01.bostonme.sh`  
 - **Port:** `443`
-- **TSL:** `true`
+- **TLS:** `true`
 - **Verify TLS Certificate:** `true`
 - **Transport:** WebSockets  
 - **Authentication:** Auth token enabled  - [Meshcore-decoder](https://github.com/michaelhart/meshcore-decoder)
 - **Token audience:** `mqttmc01.bostonme.sh`
+
+You can confirm whether your node is showing up on our MQTT infrastructure here:
+
+- **MQTT Dashboard:** https://mcmqttdashboard.bostonme.sh/
 
 ---
 
@@ -30,12 +35,14 @@ Use these broker settings:
 
 You can also upload your packets to the **[LetsMesh MeshCore Packet Analyzer](https://analyzer.letsmesh.net/)**.
 
-During setup with the software above, you’ll be asked if you want to upload to LetsMesh. **Say yes**, and set the **IATA code to `BOS`**. After that, it will ask if you’d also like to upload to a **custom MQTT server** (that’s where you’d enter the Greater Boston Mesh broker settings from above).
+Greater Boston Mesh's MQTT server **does not** automatically upload your traffic to LetsMesh.
+
+If you want packets to appear on LetsMesh, you must add LetsMesh as an additional broker/output in your push-agent configuration, alongside the Greater Boston Mesh broker settings above.
+
+When configuring LetsMesh, set the **IATA code to `BOS`**.
 
 This site shows **live packets by region**, so to view Greater Boston Mesh traffic you’ll want to select the **`BOS`** region. It’s a super handy “sanity check” for range, because it helps answer the big question:
 
 **Did my message get heard by the greater mesh… or only by my local node/nearby neighbors?**
 
 If you see your packets appearing in the feed, that’s strong proof your transmissions are making it out into the wider MeshCore ecosystem, not just echoing around locally.
-
-

--- a/docs/MeshCore/meshcore-resources.md
+++ b/docs/MeshCore/meshcore-resources.md
@@ -60,32 +60,13 @@ Our live map is the quickest way to see active nodes, recent activity, and overa
 
 ## Wardriving
 
-### Coverage Map: Primary Method
+Wardriving coverage mapping is now done with **MeshMapper**.
 
-Our [self-hosted coverage map](https://github.com/nullrouten0/meshcore-coverage-map) focuses on **RF coverage and reach**. Use this when you want a “where does this node actually get out?” view, or when planning new repeater locations.
-
-Want to contribute coverage data? See our wardriving guide:
+For setup details and links, see:
 
 - Wardriving How-To: https://bostonme.sh/docs/MeshCore/meshcore-wardrive
-- Coverage Map: https://coveragemap.bostonme.sh/
-
-### Wardriving App (Android)
-
-This [Android-only wardriving app](https://github.com/mintylinux/Meshcore-Wardrive-Android) records MeshCore reception data and stores it **locally on your phone first**. It’s a great way to test **node placement and RF coverage** (what your device can hear in different locations), not whether the entire network can hear your message.
-
-Uploading is **optional**, but we host a coverage site so users can upload their samples if they’d like. 
-
-- Coverage Map: https://coveragemap2.bostonme.sh/
-- Upload URL:
-```
-https://coveragemap2.bostonme.sh/api/samples
-```
-
-### MeshMapper
-
-[MeshMapper](https://wiki.meshmapper.net/) is another visualization and exploration tool that’s great for browsing node placement and coverage patterns.
-
-- MeshMapper: https://bos.meshmapper.net/
+- MeshMapper Map: https://bos.meshmapper.net/
+- MeshMapper Wiki: https://wiki.meshmapper.net/
 
 ## More resources
 

--- a/docs/MeshCore/meshcore-wardrive.md
+++ b/docs/MeshCore/meshcore-wardrive.md
@@ -31,7 +31,8 @@ Install the MeshMapper app for your platform:
 
 If you need help, create a support ticket:
 
-- [https://meshmapper.net/?createticket](https://meshmapper.net/?createticket)
+- Main website: [https://meshmapper.net/?createticket](https://meshmapper.net/?createticket)
+- GitHub issues: [https://github.com/MeshMapper/MeshMapper_Project/issues/new/choose](https://github.com/MeshMapper/MeshMapper_Project/issues/new/choose)
 
 Join the MeshMapper Discord community:
 

--- a/docs/MeshCore/meshcore-wardrive.md
+++ b/docs/MeshCore/meshcore-wardrive.md
@@ -1,107 +1,38 @@
 ---
 id: meshcore-wardrive
 title: MeshCore Wardrive
-sidebar_label: Meshcore Wardrive
+sidebar_label: MeshCore Wardrive
 ---
 
-# Contributing to the MeshCore Coverage Map
+# Wardriving with MeshMapper
 
-The **[MeshCore Coverage Map](https://coveragemap.bostonme.sh/)** is a crowd-sourced visualization of repeater coverage in the MeshCore mesh network.
+We now use **MeshMapper** for wardriving and coverage mapping.
 
-It’s built from real-world “can I reach the mesh from here?” pings, submitted by community members while moving around (walking, driving, biking, etc.).
+## Coverage Map (Boston)
 
----
+Use the Boston MeshMapper map here:
 
-## Map legend
+- [https://bos.meshmapper.net/](https://bos.meshmapper.net/)
 
-- **Green dot**: the mesh was reachable at that location (visible for 1 day)
-- **Red dot**: the mesh was *not* reachable at that location (visible for 1 day)
-- **Green box**: the mesh was reachable in that region
-- **Red box**: the mesh was *not* reachable in that region
-- **Dashed line**: links a green dot/box to its 1st hop repeater(s)
-- **Blue dot**: repeater with an advert in the past 1 day
-- **Light gray dot**: repeater with an advert in the past 5 days
-- **Dark gray dot**: repeater without an advert in the past 5 days
+## MeshMapper Wiki
 
-## How it works
+For setup guides, usage details, and documentation:
 
-Coverage points are created when your location gets sent to **`#wardrive`** in the format:
+- [https://wiki.meshmapper.net/](https://wiki.meshmapper.net/)
 
-`lat.xxxx lon.yyyy`
+## Mobile Apps
 
-If a repeater in your mesh network hears it, the bot can add a point to the map indicating whether you could reach the mesh from that spot.  
+Install the MeshMapper app for your platform:
 
-To also log “misses” (places you *can’t* reach the mesh), use the Wardrive web app, which automates pings and reports both hits and misses.
+- iOS: [https://apps.apple.com/us/app/meshmapper/id6758073991](https://apps.apple.com/us/app/meshmapper/id6758073991)
+- Android: [https://play.google.com/store/apps/details?id=net.meshmapper.app](https://play.google.com/store/apps/details?id=net.meshmapper.app)
 
-### MQTT Observers (Greater Boston)
+## Help and Support
 
-Greater Boston currently uses the same MQTT Observers as [LetsMesh](https://analyzer.letsmesh.net/status/observers?region=BOS).
+If you need help, create a support ticket:
 
-- `C3PO`
-- `DeputyDawg - Observer`
-- `Dighton 1 - V4`
-- `Georgetown-MA-Room`
-- `MNK`
-- `PR-Room-Server`
-- `South Plymouth MQTT`
-- `WAL-SE Room Server`
-- `YC-Observer`
-- `https://letsme.sh/ - 01`
-- `https://letsme.sh/ - 02`
-- `tyqre-observer`
+- [https://meshmapper.net/?createticket](https://meshmapper.net/?createticket)
 
-For your coverage points to appear, your `#wardrive` messages must be observed (seen) by one of the above observers.
+Join the MeshMapper Discord community:
 
-## The easiest way to contribute: the Wardrive web app
-
-Use the **[MeshCore Wardrive app](https://coveragemap.bostonme.sh/wardrive)** on your phone. It connects to your companion radio over BLE and can:
-
-- Send **single pings** on demand.
-- Run **Auto Ping** that sends a ping when needed (preferred).
-- Report both **reachability** and **non-reachability** so the map fills in faster and more accurately.
-
-## Recommended mode
-Use **Fill Missing Tiles** mode. It checks periodically whether your current coverage tile needs an update and only pings when needed. This reduces duplicates and helps the map improve faster.
-
-## Using the Wardrive app
-
-### Quick start
-
-1. Open **https://coveragemap.bostonme.sh/wardrive**
-2. Allow **Bluetooth** + **Location** permissions when prompted
-3. Click **Connect via BLE** and select your companion radio
-4. Use one of:
-   - **Send 1 Ping** (manual)
-   - **Start Auto Ping** (best for wardriving)
-
----
-
-### Important notes
-
-- Your companion radio must have the **`#wardrive`** channel (the app can help with that).
-- **Safari is not supported.**
-  - On macOS: use **Chrome** or **Edge**
-  - On iOS: use [Bluefy (Web BLE Browser)](https://apps.apple.com/us/app/bluefy-web-ble-browser/id1492822055)
-- **BLE only allows one connection at a time**, so you must disconnect from the MeshCore app before connecting in the Wardrive app.
-- If you use Auto Ping, keep the page **in the foreground** with the screen **on and unlocked**.
-
-**Don’t spam the mesh**
-The mesh is a shared resource. Please be judicious with pings and avoid creating unnecessary duplicates.
-
----
-
-### If you’re using a mobile repeater (car-peater)
-
-If your wardriving setup includes a **mobile repeater**, use the app’s **Ignore Repeater ID** feature to exclude it from the path. Otherwise, the coverage paths can become misleading.
-
-## Privacy
-
-The service stores only:
-
-- The **location** you send to `#wardrive`
-- The **ID of the 1st hop repeater**
-
-The Wardrive web app sends your location to `#wardrive` **and** to the service. Logging in the web app is stored **locally** on your device.
-
-**Public channel reminder**
-Your companion radio’s name is sent along with your location to `#wardrive`, which is a public channel.
+- [https://discord.gg/WdAeFKRne](https://discord.gg/WdAeFKRne)

--- a/src/pages/meshcore.js
+++ b/src/pages/meshcore.js
@@ -64,8 +64,8 @@ export default function Home() {
             <iframe id="meshcore-map-iframe" src="https://live.bostonme.sh/?lat=42.42648&lon=-71.21613&zoom=10&layer=dark&history=off&heat=on&labels=off&nodes=on&legend=on&menu=on&units=mi&history_filter=0" title="meshcore-live-packet-map" width="100%" height="600"></iframe>
             <h2><a href="https://analyzer.letsmesh.net/map?lat=42.36037&long=-71.18462&zoom=9" target="_blank" rel="noopener noreferrer">MeshCore Analyzer Map</a></h2>
             <iframe id="meshcore-map-iframe" src="https://analyzer.letsmesh.net/map?lat=42.36037&long=-71.18462&zoom=9" title="meshcore-letsmesh-map" width="100%" height="600"></iframe>
-            <h2><a href="https://coveragemap.bostonme.sh/" target="_blank" rel="noopener noreferrer">Coverage Map</a></h2>
-            <iframe id="meshcore-map-iframe" src="https://coveragemap.bostonme.sh/" title="meshcore-coverage-map" width="100%" height="600"></iframe>
+            <h2><a href="https://bos.meshmapper.net/" target="_blank" rel="noopener noreferrer">MeshMapper Coverage Map</a></h2>
+            <iframe id="meshcore-map-iframe" src="https://bos.meshmapper.net/" title="meshmapper-coverage-map" width="100%" height="600"></iframe>
 
           </div>
         </section>


### PR DESCRIPTION
## Summary

This PR updates MeshCore documentation and the MeshCore page to complete the transition from legacy coverage maps to MeshMapper.

---

## What Changed

* Updated wardriving documentation to use **MeshMapper** as the primary workflow.
* Removed legacy and non-MeshMapper coverage map references from resources.
* Updated the MeshCore page coverage section:

  * Replaced old coverage map link with: [https://bos.meshmapper.net/](https://bos.meshmapper.net/)
  * Replaced old coverage iframe with MeshMapper iframe
  * Updated heading to **“MeshMapper Coverage Map”**
* Updated MQTT documentation:

  * Added MQTT dashboard link: [https://mcmqttdashboard.bostonme.sh/](https://mcmqttdashboard.bostonme.sh/)
  * Clarified that Boston MQTT does not auto-upload to LetsMesh
  * Added guidance for configuring LetsMesh as an additional broker/output
  * Added MeshCore HA Add-on to supported push-agent options
  * Updated wording from 2 to 3 supported options
  * Fixed typo: `TSL` → `TLS`

---

## Files Updated

* `docs/MeshCore/meshcore-wardrive.md`
* `docs/MeshCore/meshcore-resources.md`
* `docs/MeshCore/meshcore-mqtt.md`
* `src/pages/meshcore.js`

---

## User Impact

* MeshMapper is now presented as the canonical coverage and wardriving path.
* MQTT onboarding and troubleshooting is clearer via the dashboard reference.
* Reduces confusion about Boston MQTT forwarding behavior to LetsMesh.
