### PR TITLE
MeshCore docs + mobile hero fixes + branding cleanup

### DIFF
--- a/docs/MeshCore/meshcore-letsmesh-observer.md
+++ b/docs/MeshCore/meshcore-letsmesh-observer.md
@@ -1,0 +1,44 @@
+---
+id: meshcore-letsmesh-observer
+title: MeshCore LetsMesh Observer
+sidebar_label: LetsMesh Observer
+---
+
+# MeshCore LetsMesh Observer
+
+LetsMesh analyzer: https://analyzer.letsmesh.net/
+
+## What Is LetsMesh?
+
+LetsMesh is a packet analyzer and observer network for MeshCore. It collects packet reports from observer nodes to help communities understand coverage, routing quality, and overall network behavior.
+
+## What Does an Observer Do?
+
+An observer is an MQTT-connected MeshCore node that reports packets it hears to LetsMesh. Observers can be repeater, room server, or companion setups depending on your node type.
+
+## Boston Observer Status
+
+You can view active observers for Greater Boston here:
+
+- https://analyzer.letsmesh.net/status/observers?region=BOS
+
+## Set Up an Observer
+
+To set up your own observer, follow the LetsMesh onboarding instructions:
+
+- https://analyzer.letsmesh.net/observer/onboard
+
+## Also Upload to Boston MQTT
+
+If you are already uploading to LetsMesh, you might as well also upload to the Greater Boston Mesh MQTT server to help improve local visibility and our live map.
+
+When your setup asks about additional/custom brokers, choose **yes** and add Boston MQTT.
+
+- Boston MQTT setup doc: https://bostonme.sh/docs/MeshCore/meshcore-mqtt
+You can view the local [Live Map](https://live.bostonme.sh/) once your uploads are flowing.
+
+## MeshMapper + Wardriving
+
+MeshMapper for Boston runs off LetsMesh observer data. For MeshMapper links and wardriving details, see:
+
+- https://bostonme.sh/docs/MeshCore/meshcore-wardrive

--- a/docs/MeshCore/meshcore-mqtt.md
+++ b/docs/MeshCore/meshcore-mqtt.md
@@ -5,15 +5,17 @@ sidebar_label: Meshcore MQTT
 ---
 # MeshCore MQTT Server
 
-Greater Boston Mesh runs its own MQTT server to populate our **[MeshMapper Coverage Map](https://bos.meshmapper.net/)** and **[Live Packet Map](https://live.bostonme.sh/)**.
+Greater Boston Mesh runs its own MQTT server to power our **[Live Packet Map](https://live.bostonme.sh/)** and local packet visibility tools.
 
-The coverage map requires coverage verification via MQTT, so if you are not connected to the Greater Boston Mesh, you’ll need to connect your node to the MQTT server.
+To upload to the Greater Boston Mesh MQTT server, you can use the same LetsMesh onboarding flow and choose to add another/custom broker when prompted in the install script:
 
-There are three supported push-agent options. Pick the one that matches how you connect to your node:
+- LetsMesh Add Observer: https://analyzer.letsmesh.net/observer/onboard
 
-- [MeshCore-to-MQTT (repeater/roomserver style):](https://github.com/Cisien/meshcoretomqtt)
-- [MeshCore Packet Capture (companion):](https://github.com/agessaman/meshcore-packet-capture)
-- [MeshCore HA Add-on (Home Assistant):](https://meshcore-dev.github.io/meshcore-ha/docs/ha/mqtt)
+Or use the direct GitHub tools below.
+
+- [MeshCore-to-MQTT (Repeater/Room Server):](https://github.com/Cisien/meshcoretomqtt)
+- [MeshCore Packet Capture (Companion):](https://github.com/agessaman/meshcore-packet-capture)
+- [MeshCore HA Add-on (Companion via Home Assistant):](https://meshcore-dev.github.io/meshcore-ha/docs/ha/mqtt)
 
 Use these broker settings:
 
@@ -28,21 +30,3 @@ Use these broker settings:
 You can confirm whether your node is showing up on our MQTT infrastructure here:
 
 - **MQTT Dashboard:** https://mcmqttdashboard.bostonme.sh/
-
----
-
-# LetsMesh MeshCore Packet Analyzer
-
-You can also upload your packets to the **[LetsMesh MeshCore Packet Analyzer](https://analyzer.letsmesh.net/)**.
-
-Greater Boston Mesh's MQTT server **does not** automatically upload your traffic to LetsMesh.
-
-If you want packets to appear on LetsMesh, you must add LetsMesh as an additional broker/output in your push-agent configuration, alongside the Greater Boston Mesh broker settings above.
-
-When configuring LetsMesh, set the **IATA code to `BOS`**.
-
-This site shows **live packets by region**, so to view Greater Boston Mesh traffic you’ll want to select the **`BOS`** region. It’s a super handy “sanity check” for range, because it helps answer the big question:
-
-**Did my message get heard by the greater mesh… or only by my local node/nearby neighbors?**
-
-If you see your packets appearing in the feed, that’s strong proof your transmissions are making it out into the wider MeshCore ecosystem, not just echoing around locally.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -119,7 +119,7 @@ const config = {
           },
           {
             to: '/meshcore',
-            label: 'Meshcore',
+            label: 'MeshCore',
             position: 'left'
           },
           {

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -5,10 +5,10 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 const FeatureList = [
   {
-    title: 'Meshcore',
+    title: 'MeshCore',
     url: '/meshcore',
     img: require('@site/static/img/meshcore.png').default,
-    altText: 'Meshcore logo',
+    altText: 'MeshCore logo',
     imgClassName: styles.meshcoreLogo,
     description: (
       <>

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -56,7 +56,18 @@
 }
 
 .hero .button {
-  margin-right: 2rem;
+  margin-right: 0;
+}
+
+@media (max-width: 768px) {
+  .hero .hero__title {
+    font-size: 2.1rem;
+    line-height: 1.2;
+  }
+
+  .hero .button {
+    margin-right: 0;
+  }
 }
 
 section {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -15,7 +15,7 @@ function HomepageHeader() {
         <Heading as="h1" className="hero__title">
           Off-Grid Communication <br></br> for the Greater Boston Area
         </Heading>
-        {/* <p className="hero__subtitle">Meshtastic, Meshcore, and more!</p> */}
+        {/* <p className="hero__subtitle">Meshtastic, MeshCore, and more!</p> */}
       </div>
     </header>
   );
@@ -33,7 +33,7 @@ export default function Home() {
           <div className="container">
             <h2>What is the Greater Boston Mesh?</h2>
             <div className="about-description">
-              <p>The Greater Boston Mesh is a volunteer-led, open community project focused on building a secure and reliable off-grid communication network throughout the greater Boston area, using affordable, low-power radio devices. The area has two parallel networks running on Meshcore and Meshtastic.</p>
+              <p>The Greater Boston Mesh is a volunteer-led, open community project focused on building a secure and reliable off-grid communication network throughout the greater Boston area, using affordable, low-power radio devices. The area has two parallel networks running on MeshCore and Meshtastic.</p>
             </div>
 
             <Link

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -20,4 +20,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 1rem;
+}
+
+@media screen and (max-width: 768px) {
+  .buttons {
+    flex-direction: column;
+    align-items: center;
+  }
 }

--- a/src/pages/meshcore.js
+++ b/src/pages/meshcore.js
@@ -25,12 +25,12 @@ export default function Home() {
   const { siteConfig } = useDocusaurusContext();
   return (
     <Layout
-      title={`Meshcore - ${siteConfig.title}`}
+      title={`MeshCore - ${siteConfig.title}`}
     >
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
         <div className="container">
           <Heading as="h1" className="hero__title">
-            Meshcore
+            MeshCore
           </Heading>
           <div className={styles.buttons}>
             <Link
@@ -49,9 +49,9 @@ export default function Home() {
       <main className="meshcore">
         <section id="repeaters" className="repeaters light-bg">
           <div className="container">
-            <h2>What is Meshcore?</h2>
+            <h2>What is MeshCore?</h2>
             <div className="about-description">
-              <p>Meshcore is a multi-platform system for enabling secure text-based communications utilizing LoRa radio hardware. It can be used for Off-Grid Communication, Emergency Response & Disaster Recovery, Outdoor Activities, Tactical Security including law enforcement, private security and also IoT sensor networks.</p>
+              <p>MeshCore is a multi-platform system for enabling secure text-based communications utilizing LoRa radio hardware. It can be used for Off-Grid Communication, Emergency Response & Disaster Recovery, Outdoor Activities, Tactical Security including law enforcement, private security and also IoT sensor networks.</p>
               <p><a href="https://meshcore.co.uk/" target="_blank" rel="noopener">Learn more about MeshCore →</a></p>
             </div>
           </div>
@@ -76,9 +76,9 @@ export default function Home() {
           <div className="container">
             <h2>Join the Network</h2>
             <div className="contact-grid">
-              {/* Meshcore */}
+              {/* MeshCore */}
               <div className="contact-card">
-                <h3>Meshcore Radio Settings</h3>
+                <h3>MeshCore Radio Settings</h3>
                 <div className="radio-settings-table">
                 <table className="radio-table">
                   <tbody>
@@ -115,8 +115,8 @@ export default function Home() {
                 </div>
               </div>
               <div class="contact-card">
-                <h3>Meshcore Channel</h3>
-                <p><strong>Meshcore Channel:</strong></p>
+                <h3>MeshCore Channel</h3>
+                <p><strong>MeshCore Channel:</strong></p>
                 <div class="channel-list">
                   <code class="channel-pill">Public</code>
                   <code class="channel-pill">#chat</code>


### PR DESCRIPTION
## Summary

This PR updates MeshCore documentation and UI to reflect the current **MeshMapper and LetsMesh workflows**, improves mobile hero layout behavior, and normalizes **MeshCore branding** across main pages.

---

## Documentation Changes

* Added new LetsMesh observer documentation:

  * `docs/MeshCore/meshcore-letsmesh-observer.md`
* Updated MQTT documentation to:

  * Focus on **Boston MQTT configuration**
  * Reference LetsMesh onboarding (`/observer/onboard`) as the same workflow users can follow before adding Boston as an additional broker
  * Remove outdated or duplicated LetsMesh sections now covered by the new observer documentation
* The new observer documentation includes:

  * What LetsMesh is
  * What observers do
  * BOS observer status page reference
  * Observer onboarding link
  * Guidance to also upload to **Boston MQTT** for local live map visibility
  * Note describing the relationship with **MeshMapper and wardriving**

---

## Frontend / UI Changes

### Mobile Hero Improvements #1 

* Adjusted hero title size for smaller screens
* Hero buttons now stack vertically on mobile while remaining centered
* Applied consistently across **MeshCore and Meshtastic hero sections** (shared `.buttons` behavior)

### Navigation

* Updated navbar label from **Meshcore → MeshCore**

---

## Branding Cleanup

Normalized **Meshcore → MeshCore** where relevant across main pages and UI components:

* MeshCore page content
* Homepage text references
* Homepage feature card label and alt text
* Navbar item label

---

## Files Changed

* `docs/MeshCore/meshcore-mqtt.md`
* `docs/MeshCore/meshcore-letsmesh-observer.md` *(new)*
* `docusaurus.config.js`
* `src/components/HomepageFeatures/index.js`
* `src/css/custom.scss`
* `src/pages/index.js`
* `src/pages/index.module.css`
* `src/pages/meshcore.js`

---

## Validation

* Restarted `bostonmesh.service` after changes
* Verified service is active and serving on **port 3000 (HTTP 200)**
