### PR TITLE
README refresh, community links cleanup, and dark mode polish

### DIFF
--- a/LOCAL_DEVELOPMENT.md
+++ b/LOCAL_DEVELOPMENT.md
@@ -1,0 +1,33 @@
+# Local Development
+
+This website is built with [Docusaurus](https://docusaurus.io/).
+
+## Install Dependencies
+
+Using yarn:
+
+```bash
+yarn
+```
+
+Using npm:
+
+```bash
+npm i
+```
+
+## Run Locally
+
+Using yarn:
+
+```bash
+yarn start
+```
+
+Using npm:
+
+```bash
+npm run start
+```
+
+This starts the local development server at `http://localhost:3000` with hot reload.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Greater Boston Mesh
+<h1 align="center">Greater Boston Mesh</h1>
 
-![Greater Boston Mesh Logo](./static/img/logo.png)
+<p align="center">
+  <img src="./static/img/logo.png" alt="Greater Boston Mesh Logo" width="50%" />
+</p>
 
 Greater Boston Mesh is a volunteer-led community building resilient, off-grid communications across the Greater Boston area.
 

--- a/README.md
+++ b/README.md
@@ -1,64 +1,27 @@
-# How to run locally
+# Greater Boston Mesh
 
-This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
+![Greater Boston Mesh Logo](./static/img/logo.png)
 
-### Install packages
+Greater Boston Mesh is a volunteer-led community building resilient, off-grid communications across the Greater Boston area.
 
-Using yarn:
-```bash
-yarn
-```
+We support and document practical mesh networking workflows, including:
+- **MeshCore**
+- **Meshtastic**
 
-Using npm:
-```
-npm i
-```
+## Website
 
-### Local Development
+- Main site: https://bostonme.sh/
 
-Using yarn:
-```bash
-yarn start
-```
+## Documentation
 
-Using npm:
-```
-npm run start
-```
+- Docs home: https://bostonme.sh/docs/Introduction
+- MeshCore docs: https://bostonme.sh/docs/category/meshcore
+- Meshtastic docs: https://bostonme.sh/docs/category/meshtastic
 
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server. You can also visit `localhost:3000` directly. 
+## Contributing
 
-# How to make changes
+- Contributing docs: https://bostonme.sh/docs/contributing-docs
 
-## Updating documentation
+## Run Locally
 
-Docs all live under `/docs`. Add any files and subfolders you'd like, and they will appear automatically in the sidebar!
-
-If we want to explicitly specify an order of sidebar links, we can do so by modifying `sidebars.js`. 
-
-## Updating the header/footer
-
-Header and footer settings can be configed via `docusaurus.config.js`. Header settings, including a list of nav bar links, are listed under `themeConfig > navbar`. Footer settings are under `themeconfig > footer`.
-
-## Updating the home page
-
-The home page is powered by `src/pages/index.js`. We can modify the html (actually JSX) contained within that file to update the home page. 
-
-## Updating styling
-
-You can update styles by modifying `src/css/custom.scss`.
-
-## Creating new pages
-
-You can add new pages to `src/pages`, following the same structure as `index.js`. These pages will become available under the URL `/bostonmesh/your_page_name`. 
-
-### Writing static HTML
-
-If you prefer to write static HTML, and then see that contents appear within the header/footer, you can do the following:
-
-1. Create a new HTML file: `static/your_new_page.html`. Populate this page with any contents that you want. This page does _not_ need to include any header, footer, etc.
-2. Create a new file `src/pages/your_new_page.js`.
-3. Copy-and-paste the contents of `src/pages/test_page.js` into your new page.
-  a. Replace `test_page.html` with `your_new_page.html`
-4. Your new page should now be visible at `/bostonmesh/your_page_name`.
-
+- Local development notes: [LOCAL_DEVELOPMENT.md](./LOCAL_DEVELOPMENT.md)

--- a/docs/community-spaces.md
+++ b/docs/community-spaces.md
@@ -1,14 +1,19 @@
 # Related Communities
 
-The [Greater Boston Mesh discord](https://discord.gg/MUVASVEEES) serves as the primary space for coordiantion and discussion.
+The [Greater Boston Mesh Discord](https://discord.gg/MUVASVEEES) is our primary space for coordination and discussion.
 
-In addition, the following online spaces exist and can also be helpful to join:
+## Regions
 
-- [NHMesh Discord](https://discord.gg/PkbHWSEXBv)
-  - There is a significant amount of overlap between the Boston area mesh and the New Hampshire mesh, so many folks are part of both Discords servers.
+You may also find these regional communities helpful:
+
+- [NHMesh Discord](https://discord.gg/PkbHWSEXBv)  
+  There is significant overlap between Greater Boston Mesh and NHMesh, and many members participate in both.
 - [SouthCoast Mesh Discord](https://discord.gg/sZudrRnua5) | [Website](https://southcoastmesh.com/)
-- [Boston Meshnet Facebook group](https://www.facebook.com/groups/376287875353461)
 - [CT Mesh Discord](https://discord.gg/m4F328as3K) | [Website](https://ctmesh.org/)
-- [Official Meshcore Discord](https://discord.gg/bSuST8xvet)
-- [Official Meshtastic Discord](https://discord.gg/meshtastic)
-  - [Massachusetts area chat](https://discord.com/channels/867578229534359593/1201546802437042286)
+- [Boston Meshnet Facebook Group](https://www.facebook.com/groups/376287875353461)
+
+## Official Discords
+
+- [Official MeshCore Discord](https://discord.gg/bSuST8xvet)
+- [Official Meshtastic Discord](https://discord.gg/meshtastic) | [Massachusetts Area Chat](https://discord.com/channels/867578229534359593/1201546802437042286)
+- [Official MeshMapper Discord](https://discord.gg/WdAeFKRne)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -100,9 +100,9 @@ const config = {
       // Replace with your project's social card
       image: 'img/social-card.jpg',
       colorMode: {
-        defaultMode:	'light',
-        respectPrefersColorScheme: false,
-        disableSwitch: true
+        defaultMode: 'light',
+        respectPrefersColorScheme: true,
+        disableSwitch: false
       },
       navbar: {
         title: 'Greater Boston Mesh',

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -19,8 +19,12 @@
   --shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   --shadow-hover: 0 8px 16px rgba(0, 0, 0, 0.2);
   --text-light: #666;
+  --text-dark: #1f2937;
   --dark-bg: #1a1a1a;
   --light-bg: #f5f5f5;
+  --surface-bg: #ffffff;
+  --surface-muted: #f0f5ff;
+  --surface-border: #d0e0ff;
   --primary-color: #1565C0;
   --secondary-color: #4CAF50;
   --accent-color: #FF5722;
@@ -28,14 +32,20 @@
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme='dark'] {
-  --ifm-color-primary: #25c2a0;
-  --ifm-color-primary-dark: #21af90;
-  --ifm-color-primary-darker: #1fa588;
-  --ifm-color-primary-darkest: #1a8870;
-  --ifm-color-primary-light: #29d5b0;
-  --ifm-color-primary-lighter: #32d8b4;
-  --ifm-color-primary-lightest: #4fddbf;
+  --ifm-color-primary: #2e8555;
+  --ifm-color-primary-dark: #29784c;
+  --ifm-color-primary-darker: #277148;
+  --ifm-color-primary-darkest: #205d3b;
+  --ifm-color-primary-light: #33925d;
+  --ifm-color-primary-lighter: #359962;
+  --ifm-color-primary-lightest: #3cad6e;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+  --light-bg: #111827;
+  --surface-bg: #1f2937;
+  --surface-muted: #111827;
+  --surface-border: #374151;
+  --text-light: #9ca3af;
+  --text-dark: #e5e7eb;
 }
 
 .header-icon {
@@ -53,6 +63,10 @@
   }
 
   .iconExternalLink_nPIU { display: none; }
+}
+
+[data-theme='dark'] .header-icon.github {
+  filter: invert(1);
 }
 
 .hero .button {
@@ -104,7 +118,7 @@ section.light-bg {
 }
 
 .repeater-card {
-  background: white;
+  background: var(--surface-bg);
   border-radius: var(--border-radius);
   box-shadow: var(--shadow);
   overflow: hidden;
@@ -191,7 +205,7 @@ section.light-bg {
 }
 
 .map-legend {
-  background: white;
+  background: var(--surface-bg);
   padding: 15px;
   border-radius: var(--border-radius);
   box-shadow: var(--shadow);
@@ -245,7 +259,7 @@ section.light-bg {
 }
 
 .contact-card {
-  background: white;
+  background: var(--surface-bg);
   padding: 30px;
   border-radius: var(--border-radius);
   box-shadow: var(--shadow);
@@ -269,8 +283,8 @@ section.light-bg {
 
 /* MeshCore Channel styles */
 .channel-hash {
-  background: #f0f5ff;
-  border: 1px solid #d0e0ff;
+  background: var(--surface-muted);
+  border: 1px solid var(--surface-border);
   border-radius: 5px;
   padding: 15px;
   margin: 15px 0;
@@ -305,8 +319,8 @@ section.light-bg {
 }
 
 .channel-pill {
-  background: #f0f5ff;
-  border: 1px solid #d0e0ff;
+  background: var(--surface-muted);
+  border: 1px solid var(--surface-border);
   border-radius: 999px;
   padding: 6px 10px;
   font-family: 'Courier New', Courier, monospace;


### PR DESCRIPTION
## Summary

This PR focused on improving project presentation, documentation structure, and theme/UI behavior.

---

## Included Commits

* `1a97058` – Refresh README, docs structure, and dark mode/mobile polish
* `fd1ab45` – Center README title and reduce logo display size

---

## What Changed

### 1. README and Local Development Docs

* Reworked `README.md` to be **Greater Boston Mesh–focused**, including:

  * Website and documentation links
  * Contributing documentation link
* Added centered title and logo presentation.
* Added `LOCAL_DEVELOPMENT.md` containing local install and run instructions.
* README now links to `LOCAL_DEVELOPMENT.md` for local setup.

---

### 2. Related Communities Page Cleanup

Updated `docs/community-spaces.md` with improved structure and wording.

Changes include:

* Split links into clearer sections:

  * **Regions**
  * **Official Discords**
* Added **MeshMapper Discord**
* Fixed capitalization, typos, and overall consistency.

---

### 3. Dark Mode and Theme Improvements

Updated theme configuration and styling for better dark mode behavior.

* `docusaurus.config.js`

  * Enabled dark mode toggle
  * Added system preference support

* `src/css/custom.scss`

  * Added theme-aware surface, background, and text variables
  * Removed hardcoded white panel backgrounds that caused bright blocks in dark mode
  * Fixed GitHub icon visibility in dark mode
  * Ensured dark mode uses the same **green primary palette** as light mode

---

## Files Changed

* `README.md`
* `LOCAL_DEVELOPMENT.md` *(new)*
* `docs/community-spaces.md`
* `docusaurus.config.js`
* `src/css/custom.scss`
