### PR TITLE
Update README links and add Dark Reader lock tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ We support and document practical mesh networking workflows, including:
 ## Documentation
 
 - Docs home: https://bostonme.sh/docs/Introduction
-- MeshCore docs: https://bostonme.sh/docs/category/meshcore
-- Meshtastic docs: https://bostonme.sh/docs/category/meshtastic
+- MeshCore docs: https://bostonme.sh/docs/MeshCore
+- Meshtastic docs: https://bostonme.sh/docs/Meshtastic
 
 ## Contributing
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -13,6 +13,14 @@ const config = {
   title: 'Boston Mesh',
   tagline: '',
   favicon: 'img/favicon.ico',
+  headTags: [
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'darkreader-lock',
+      },
+    },
+  ],
 
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
   future: {


### PR DESCRIPTION
* Updated `README.md` documentation links to use direct section paths instead of category URLs:

  * [https://bostonme.sh/docs/MeshCore](https://bostonme.sh/docs/MeshCore)
  * [https://bostonme.sh/docs/Meshtastic](https://bostonme.sh/docs/Meshtastic)

* Added a **Dark Reader lock** meta tag in the Docusaurus configuration to prevent browser extensions from applying a second dark-theme inversion:

```html
<meta name="darkreader-lock">
```
