### PR TITLE
Adding/adapting the regional chat announcement to documentation.

### DIFF
--- a/docs/MeshCore/meshcore-channels.md
+++ b/docs/MeshCore/meshcore-channels.md
@@ -10,7 +10,7 @@ sidebar_label: MeshCore Channels
 
 _Note: This was adapted from an announcement on Discord in early April_
 
-The [New Hampshire Mesh made an announcement](https://discord.com/channels/1323830453383331880/1456263597100498974/1490524392898171072) about organizing their region in order to be good mesh stewards and to prioritize good mesh hygiene. This push proposes the segmenting of certain channels or channel types by region. Instead of a blast to `Public` - which could have packets flood much farther than intended - a mesh user can target/tune their communication to something more local.
+The [New Hampshire Mesh made an announcement](https://discord.com/channels/1323830453383331880/1456263597100498974/1490524392898171072) about organizing their region in order to be good mesh stewards and to prioritize good mesh hygiene. You will need to join the NHMesh Discord first to view that message; the invite is listed in [Related Communities](https://bostonme.sh/docs/community-spaces). This push proposes the segmenting of certain channels or channel types by region. Instead of a blast to `Public` - which could have packets flood much farther than intended - a mesh user can target/tune their communication to something more local.
 
 With New Hampshire implementing this practice and other nearby regions on board to do so, we should be good neighbors on the mesh and follow suit out of respect for everyone else.
 

--- a/docs/MeshCore/meshcore-channels.md
+++ b/docs/MeshCore/meshcore-channels.md
@@ -62,8 +62,6 @@ We understand that hashtag channels still will use flood packets, but as we take
 
 We need to share the mesh resources with surrounding neighbors, out of respect for all. Thus, we should do our best to adhere to the community standards our neighbors are proposing. We do not own the mesh; _it is morphing into something beyond just ourselves_.
 
-These are the common channels used in Greater Boston Mesh for MeshCore.
-
 ## Other Good Channels
 
 As of April 2026, please note that these are **not** region-locked chats.

--- a/docs/MeshCore/meshcore-channels.md
+++ b/docs/MeshCore/meshcore-channels.md
@@ -10,7 +10,7 @@ sidebar_label: MeshCore Channels
 
 _Note: This was adapted from an announcement on Discord in early April_
 
-The [New Hampshire Mesh made an announcement]() about organizing their region in order to be good mesh stewards and to prioritize good mesh hygiene. This push proposes the segmenting of certain channels or channel types by region. Instead of a blast to `Public` - which could have packets flood much farther than intended - a mesh user can target/tune their communication to something more local.
+The [New Hampshire Mesh made an announcement](https://discord.com/channels/1323830453383331880/1456263597100498974/1490524392898171072) about organizing their region in order to be good mesh stewards and to prioritize good mesh hygiene. This push proposes the segmenting of certain channels or channel types by region. Instead of a blast to `Public` - which could have packets flood much farther than intended - a mesh user can target/tune their communication to something more local.
 
 With New Hampshire implementing this practice and other nearby regions on board to do so, we should be good neighbors on the mesh and follow suit out of respect for everyone else.
 
@@ -24,7 +24,9 @@ Every unnecessary flood steals airtime from everyone. LoRa is a shared half-dupl
 
 ### What We're Asking: Use Hashtag Channels
 
-Until the MeshCore regional segmentation in firmware is stable enough for us to rely on, and enough repeaters are up-to-date with any new firmware changes, please us the appropriate hashtag channel(s) for your activity:
+Until the MeshCore regional segmentation in firmware is stable enough for us to rely on, and enough repeaters are up-to-date with any new firmware changes, please use the appropriate hashtag channel(s) for your activity:
+
+If you are brand new and have not added additional channels yet, starting in `Public` is fine. Move to regional hashtag channels once your client is configured.
 
 | Channel | Description | Status |
 | --- | --- | --- |

--- a/docs/MeshCore/meshcore-channels.md
+++ b/docs/MeshCore/meshcore-channels.md
@@ -72,7 +72,7 @@ As of April 2026, please note that these are **not** region-locked chats.
 | --- | --- |
 | `#chat` | General day-to-day conversation. |
 | `#coffee` | Local meetup and casual social coordination.|
-| `#ice-alert` | ICE (Immigration and Customs Enforcement) activity alerts and related safety updates. <br /> **NOTE**: If you think ICE is in your area, please [contact Mass LUCE 617-370-5023](tel:\+16173705023) |
+| `#ice-alert` | ICE (Immigration and Customs Enforcement) activity alerts and related safety updates. <br /> **NOTE**: If you think ICE is in your area, please [contact Mass LUCE 617-370-5023](tel:+16173705023) |
 | `#jokes` | Humor and light social traffic. |
 | `#politics` | Politics-focused discussion. |
 | `#test` | Node testing, path testing, and signal/routing checks. |
@@ -82,4 +82,4 @@ As of April 2026, please note that these are **not** region-locked chats.
 
 * Channel usage can evolve over time as community needs change.
 * For current channel practices, check in `Public` or Discord.
-* Bot/channel command reference: <https://bostonme.sh/docs/MeshCore/meshcore-bots>
+* Bot/channel command reference: [MeshCore Bot Documentation](https://bostonme.sh/docs/MeshCore/meshcore-bots)

--- a/docs/MeshCore/meshcore-channels.md
+++ b/docs/MeshCore/meshcore-channels.md
@@ -6,51 +6,80 @@ sidebar_label: MeshCore Channels
 
 # MeshCore Channels
 
+## April 2026 Update
+
+_Note: This was adapted from an announcement on Discord in early April_
+
+The [New Hampshire Mesh made an announcement]() about organizing their region in order to be good mesh stewards and to prioritize good mesh hygiene. This push proposes the segmenting of certain channels or channel types by region. Instead of a blast to `Public` - which could have packets flood much farther than intended - a mesh user can target/tune their communication to something more local.
+
+With New Hampshire implementing this practice and other nearby regions on board to do so, we should be good neighbors on the mesh and follow suit out of respect for everyone else.
+
+> **TL;DR**: How and where you transmit matters - not just for you, but for everyone in the region. This includes CT, NH, Maine, NY and RI.
+
+### The Flood Problem
+
+MeshCore's default public channel uses a flooding protocol - every node in range retransmits the packet, which propagates outward like ripples in a pond. And a _default_ of 64 hops. That is great for maximum reach! It's not so great when you're doing a war drive test in Boston and your packets are getting retransmitted by repeaters in New York City or Maine, in pursuit of confirmation that your mobile node was working.
+
+Every unnecessary flood steals airtime from everyone. LoRa is a shared half-duplex medium. We're all on the same RF budget. In this case, "unnecessary" could be better understood as untargeted. In a real world example, if you're having a conversation with a friend beside you at a party, having someone across the room use a megaphone to broadcast their own conversation may drown you out... And you may not be interested in _their_ conversation in the first place.
+
+### What We're Asking: Use Hashtag Channels
+
+Until the MeshCore regional segmentation in firmware is stable enough for us to rely on, and enough repeaters are up-to-date with any new firmware changes, please us the appropriate hashtag channel(s) for your activity:
+
+| Channel | Description | Status |
+| --- | --- | --- |
+| `#ma-mesh` | General MA chat - say hi, share a spotting, talk mesh shop with MA folks. | ➕ New Channel |
+| `#ma-hc` | Health check pings - use the new [Health Check](https://healthcheck.bostonme.sh/app) service on the website! | ➕ New Channel |
+| `#emergency` | Actual emergencies.  Flooding is appropriate here - that's the point. Keep traffic concise and relevant. | 👍 No Change |
+| `Public` | New users getting oriented, or reaching someone in a different region you can't DM. Save it for when you need the reach. | 👀 New Behavior |
+
+Similarly, New Hampshire has implemented the following channels: `#nhmesh` (their NH-focused chat) and `#nhhc` (their health check). More regional hashtags will emerge as time goes on.
+
+> **NOTE**: This is currently an _organizational_ initiative until a software/firmware solution for regional flooding is in place and sufficiently stable.
+
+### Practical Examples: What Should You Do and Where Should You Do It?
+
+* War Driving or mobile testing?
+  * `#ma-wardiving` or DM a known node. It's bad form to test that repeatedly in `Public`.
+* Chatting with Neighbors a few hops away?
+  * DM or `#ma-mesh` - Our neighbors in Rhode Island and New Hampshire probably don't need to be reached.
+* Checking if your repeater is heard on the mesh?
+  * `#ma-hc`. One ping. Wait. Done. (Or debug with the [Boston Mesh Analyzer](https://analyzer.bostonme.sh/#/live) or with the help of others on Discord.)
+* Checking if your companion is sending messages to the mesh?
+  * `#test` is a better candidate than `Public`. Though if you perform your test by saying "hello" in `#ma-mesh`, you may get folks saying "hi" back!
+* Actual "🚨Grid is Down🚨" Emergency?
+  * `Public` or `#emergency`. Flood away, that's exactly the system is for.
+
+### Be a Good Steward, Follow Best Practices
+
+We're building this for resilience, which means the network needs to work when it counts. That only happens if we treat airtime as a _shared resource_ during normal operations.
+
+If you have questions about channel setup or your device config, drop it in `#ma-mesh` or follow up in the MeshCore channels on the discord. We're happy to help!
+
+### Final Note
+
+We understand that hashtag channels still will use flood packets, but as we take the first step to  some organization, let's encourage better practices and build the muscle memory _now_ so it's not a big deal later.
+
+We need to share the mesh resources with surrounding neighbors, out of respect for all. Thus, we should do our best to adhere to the community standards our neighbors are proposing. We do not own the mesh; _it is morphing into something beyond just ourselves_.
+
 These are the common channels used in Greater Boston Mesh for MeshCore.
 
-## Channel List
+## Other Good Channels
 
-- `Public`
-- `#chat`
-- `#coffee`
-- `#emergency`
-- `#ice-alert`
-- `#jokes`
-- `#politics`
-- `#test`
-- `#weather`
+As of April 2026, please note that these are **not** region-locked chats.
 
-## Channel Purpose
-
-### `Public`
-General open traffic and first contact. Use this when joining the mesh and saying hello.
-
-### `#chat`
-General day-to-day conversation.
-
-### `#coffee`
-Local meetup and casual social coordination.
-
-### `#emergency`
-Urgent/emergency-related communication. Keep traffic concise and relevant.
-
-### `#ice-alert`
-ICE (Immigration and Customs Enforcement) activity alerts and related safety updates.
-
-### `#jokes`
-Humor and light social traffic.
-
-### `#politics`
-Politics-focused discussion.
-
-### `#test`
-Node testing, path testing, and signal/routing checks.
-
-### `#weather`
-Weather reports, forecasts, and weather-related updates.
+| Channel | Purpose |
+| --- | --- |
+| `#chat` | General day-to-day conversation. |
+| `#coffee` | Local meetup and casual social coordination.|
+| `#ice-alert` | ICE (Immigration and Customs Enforcement) activity alerts and related safety updates. <br /> **NOTE**: If you think ICE is in your area, please [contact Mass LUCE 617-370-5023](tel:\+16173705023) |
+| `#jokes` | Humor and light social traffic. |
+| `#politics` | Politics-focused discussion. |
+| `#test` | Node testing, path testing, and signal/routing checks. |
+| `#weather` | Weather reports, forecasts, and weather-related updates. |
 
 ## Notes
 
-- Channel usage can evolve over time as community needs change.
-- For current channel practices, check in `Public` or Discord.
-- Bot/channel command reference: https://bostonme.sh/docs/MeshCore/meshcore-bots
+* Channel usage can evolve over time as community needs change.
+* For current channel practices, check in `Public` or Discord.
+* Bot/channel command reference: <https://bostonme.sh/docs/MeshCore/meshcore-bots>

--- a/docs/MeshCore/meshcore-collisions.md
+++ b/docs/MeshCore/meshcore-collisions.md
@@ -6,7 +6,7 @@ sidebar_label: MeshCore Collisions
 
 # MeshCore Repeater Collisions
 
-MeshCore effectively uses the **first 2 hex characters of your public key** as a short “node ID” prefix.  
+MeshCore effectively uses the **first 2 hex characters of your public key** as a short “node ID” prefix.
 If two nodes in the same mesh share that prefix (example: `a3`), tools that rely on the short ID can get confused.
 
 This guide shows how to change your keypair so your repeater gets a **different 2-digit prefix**, using a **serial (USB) connection** and the MeshCore CLI command:
@@ -24,25 +24,23 @@ set prv.key <PRIVATE_KEY_HERE>
 
 ## What you’ll need
 
-* A PC connected to the repeater via **USB serial**
-* The **MeshCore web console**
-
-  * [https://flasher.meshcore.co.uk/](https://flasher.meshcore.co.uk/)
-* A new keypair with a **non-colliding prefix**, generated either:
-
-  * **In our Discord** using the bot command (it can generate a fresh keypair for you), or
-  * Via the web keygen: [https://gessaman.com/mc-keygen/](https://gessaman.com/mc-keygen/)
-
+- A PC connected to the repeater via **USB serial**
+- The **MeshCore web console**
+  - [https://flasher.meshcore.io/](https://flasher.meshcore.io/)
+- A new keypair with a **non-colliding prefix**, generated either:
+  - **In our Discord** using the bot command (it can generate a fresh keypair for you), or
+  - Via the web keygen: [https://gessaman.com/mc-keygen/](https://gessaman.com/mc-keygen/)
 
 ## Step 1: Check what prefixes are already in use nearby
 
 You can check prefixes a couple different ways:
 
 ### Option A: MeshCore Analyzer
-Browse the repeater list for the region `BOS - Boston, US` and look at the prefixes already in use:  
-https://analyzer.letsmesh.net/nodes/repeaters
+
+Browse the repeater list for the region `BOS - Boston, US` and look at the prefixes already in use: [LetsMesh Analyzer](https://analyzer.letsmesh.net/nodes/repeaters)
 
 ### Option B: Discord bot
+
 In the Discord server, run the command `/open` in `#meshcore-bot` channel, and check the prefixes shown there.
 
 > Goal: pick a prefix that isn’t already common around your local mesh.
@@ -57,7 +55,7 @@ You can generate a keypair either with our Discord bot **MeshBuddy** or via the 
 
 In Discord, go to the `#meshcore-bot` channel and run:
 
-* `/keygen XX`
+- `/keygen XX`
 
 Where `XX` is the first **two hex characters** of the prefix you want.
 
@@ -78,8 +76,7 @@ MeshCore expects the private key as **128 hex characters** (one continuous strin
 
 ## Step 3: Set the new private key over serial
 
-Go to:
-https://flasher.meshcore.co.uk/
+Go to the MeshCore flasher: [https://flasher.meshcore.io/](https://flasher.meshcore.io/)
 
 1. Click on `Console`
 2. Select the device in the popup window.
@@ -91,9 +88,9 @@ set prv.key <PRIVATE_KEY_HERE>
 
 ### Paste safety checklist
 
-* The key is **exactly 128 hex characters**
-* No spaces, no line breaks, no quotes
-* Make sure you didn’t accidentally copy extra characters before/after the key
+- The key is **exactly 128 hex characters**
+- No spaces, no line breaks, no quotes
+- Make sure you didn’t accidentally copy extra characters before/after the key
 
 ---
 
@@ -121,9 +118,9 @@ Changing the private key changes the node’s identity.
 
 After re-keying, you may need to update:
 
-* ACLs / allowlists that reference the old pubkey
-* Dashboards, automations, or monitoring that key off the old identity
-* Anything else that “remembers” your node by pubkey
+- ACLs / allowlists that reference the old pubkey
+- Dashboards, automations, or monitoring that key off the old identity
+- Anything else that “remembers” your node by pubkey
 
 ---
 

--- a/docs/MeshCore/meshcore-getting-started.md
+++ b/docs/MeshCore/meshcore-getting-started.md
@@ -4,16 +4,17 @@ title: MeshCore Getting Started
 sidebar_label: MeshCore Getting Started
 ---
 
-# MeshCore Getting Started  
+# MeshCore Getting Started
+
 *Greater Boston Mesh*
 
-MeshCore is the software used by Greater Boston Mesh to build a decentralized, [long-range wireless (LoRa)](https://www.semtech.com/lora/what-is-lora) messaging network using LoRa radios. Nodes communicate directly with each other, forming a mesh that does not rely on the internet or cellular service. 
+MeshCore is the software used by Greater Boston Mesh to build a decentralized, [long-range wireless (LoRa)](https://www.semtech.com/lora/what-is-lora) messaging network using LoRa radios. Nodes communicate directly with each other, forming a mesh that does not rely on the internet or cellular service.
 
 This page is intended to help you get oriented, understand your options, and figure out what to do next — without requiring deep radio or networking knowledge.
 
 If you are interested in hosting infrastructure for the network without getting deeply involved, you may also want to read [Host a Node](https://bostonme.sh/docs/host-a-node).
 
-If you are want to learn more about MeshCore in general please visit [MeshCore.co.uk](https://meshcore.co.uk/about.html).
+If you are want to learn more about MeshCore in general please visit [MeshCore.io](https://meshcore.io/about.html).
 
 ---
 
@@ -35,7 +36,7 @@ This is the easiest place to begin.
 
 You can purchase hardware made specifically for MeshCore, or flash MeshCore onto many compatible LoRa devices.
 
-If you want examples of hardware that people in the community are already using successfully, see  
+If you want examples of hardware that people in the community are already using successfully, see
 [Node Builds](https://bostonme.sh/docs/Node-Builds).
 
 ---
@@ -45,6 +46,7 @@ If you want examples of hardware that people in the community are already using 
 A repeater is an always-on node that helps extend coverage for yourself and others. Repeaters are critical to the health of the mesh, but they require more planning and coordination.
 
 Good fit if you:
+
 - Have stable power (UPS backup, solar with batteries, etc.)
 - Can place hardware reasonably high
 
@@ -59,16 +61,19 @@ A **Room Server** is a MeshCore node that hosts a **persistent group chat room**
 Instead of messages only being exchanged between individual nodes, a room server provides a shared “meeting place” where multiple people can post and read messages in the same channel. The room stays available as long as the server is online, which makes it useful for community coordination, announcements, and ongoing conversations.
 
 What it’s good for:
+
 - A **local community chat** (town/region coordination)
 - **Event coordination** (meetups, field tests, deploy days)
 - A place for **status updates** or lightweight announcements
 - Keeping a conversation going even as people come and go from coverage
 
 What it’s not:
+
 - It’s **not required** to use MeshCore day-to-day
 - It’s **not a repeater** (its job isn’t to extend RF coverage)
 
 Typical expectations:
+
 - Usually runs **always-on** (stable power, reliable placement)
 - Best hosted where it can **reach the mesh reliably**
 - More useful when the host coordinates with others so the room name/purpose is clear
@@ -94,10 +99,11 @@ In short: encrypted does not mean anonymous.
 ## What you need to get started
 
 At a minimum:
-- A supported LoRa device  
-- A USB cable  
-- A computer with a modern browser (Chrome or Edge recommended)  
-- About 10–20 minutes  
+
+- A supported LoRa device
+- A USB cable
+- A computer with a modern browser (Chrome or Edge recommended)
+- About 10–20 minutes
 
 You can purchase hardware made specifically for MeshCore, or flash MeshCore onto many compatible LoRa devices. [Heltec v4](https://heltec.org/project/wifi-lora-32-v4/) boards are our current recommendation. If you’re looking for other known-good hardware options, see [Node Builds](https://bostonme.sh/docs/Node-Builds), which links to several proven MeshCore builds used by the community.
 
@@ -108,6 +114,7 @@ You can purchase hardware made specifically for MeshCore, or flash MeshCore onto
 Antenna choice and placement often matter more than transmit power. When looking for an antenna, make sure it is designed for the correct frequency band (902–928 MHz in the US). Antennas advertised for the wrong band may perform poorly, even if they physically fit. You do not need an expensive or high-gain antenna to get started. Simple antennas matched to the correct band work well in many cases.
 
 General guidance:
+
 - An external antenna usually performs better than a small built-in antenna
 - Height and clear surroundings help more than raw power
 - Indoors, placement near a window or on a higher floor can make a noticeable difference
@@ -126,11 +133,11 @@ When you’re ready to set up your LoRa radio, the first step is loading **MeshC
 
 Typical first-time steps:
 
-1. Connect your device to your computer via USB  
-2. Open the MeshCore web flasher  
-3. Select your device (or detected port)  
-4. Choose a role (Companion USB/BLE, Repeater, Room Server)  
-5. Flash the firmware  
+1. Connect your device to your computer via USB
+2. Open the MeshCore web flasher
+3. Select your device (or detected port)
+4. Choose a role (Companion USB/BLE, Repeater, Room Server)
+5. Flash the firmware
 
 When flashing finishes, **power-cycle or restart** the radio. It should boot running the firmware you just installed.
 
@@ -174,15 +181,15 @@ Keeping consistent settings ensures stability and reduces unnecessary RF noise.
 
 These are recommendations, not hard rules. They exist to keep the mesh understandable and healthy.
 
-- Choose a name that is descriptive and reasonably unique  
-- Town- or neighborhood-based names are common  
-- Avoid extremely short or generic names  
+- Choose a name that is descriptive and reasonably unique
+- Town- or neighborhood-based names are common
+- Avoid extremely short or generic names
 
 Examples:
 
-- `BOS - North Station NE`  
-- `CMD - Central Sq - 001`  
-- `WAT - Arsenal`  
+- `BOS - North Station NE`
+- `CMD - Central Sq - 001`
+- `WAT - Arsenal`
 
 Clear naming helps with troubleshooting, mapping coverage, and general sanity.
 
@@ -231,9 +238,7 @@ Send:
 
 - `test`
 
-For more bot/channel details, see:
-
-- https://bostonme.sh/docs/MeshCore/meshcore-bots
+For more bot/channel details, see the [MeshCore bots documentation](https://bostonme.sh/docs/MeshCore/meshcore-bots)
 
 If you receive a response, that confirms your node is successfully transmitting and receiving at least one hop into the mesh.
 
@@ -255,6 +260,7 @@ You can view:
 - Which repeaters handled the traffic
 
 This helps confirm:
+
 - Your messages are reaching the wider mesh
 - You are receiving messages seen by others
 - The route quality and hop count look reasonable
@@ -280,6 +286,7 @@ These tools help diagnose placement issues, antenna problems, or configuration m
 That’s normal. MeshCore has a low barrier to entry, and you can start small.
 
 If you’re not sure where to begin:
+
 - Start with a client node
 - Leave settings mostly default
 - Ask before making major changes

--- a/docs/MeshCore/meshcore-getting-started.md
+++ b/docs/MeshCore/meshcore-getting-started.md
@@ -240,6 +240,8 @@ Send:
 
 For more bot/channel details, see the [MeshCore bots documentation](https://bostonme.sh/docs/MeshCore/meshcore-bots)
 
+After your initial setup, see the [MeshCore channels documentation](https://bostonme.sh/docs/MeshCore/meshcore-channels) for current regional channel conventions.
+
 If you receive a response, that confirms your node is successfully transmitting and receiving at least one hop into the mesh.
 
 ---

--- a/docs/boston-mesh-services.md
+++ b/docs/boston-mesh-services.md
@@ -17,7 +17,7 @@ Made by local resident [Yellowcooln](https://github.com/yellowcooln).
 
 ## MeshCore Health Check
 
-MeshCore observer coverage app that generates test codes, watches MQTT observer receipts, and scores real- world message reachability with per-observer path details. 
+MeshCore observer coverage app that generates test codes, watches MQTT observer receipts, and scores real-world message reachability with per-observer path details.
 
 - https://healthcheck.bostonme.sh/
 

--- a/docs/community-spaces.md
+++ b/docs/community-spaces.md
@@ -8,6 +8,7 @@ You may also find these regional communities helpful:
 
 - [NHMesh Discord](https://discord.gg/PkbHWSEXBv)  
   There is significant overlap between Greater Boston Mesh and NHMesh, and many members participate in both.
+- [Rhode Island Mesh Discord](https://discord.gg/RSXmVP8bP2)
 - [SouthCoast Mesh Discord](https://discord.gg/sZudrRnua5) | [Website](https://southcoastmesh.com/)
 - [CT Mesh Discord](https://discord.gg/m4F328as3K) | [Website](https://ctmesh.org/)
 - [Boston Meshnet Facebook Group](https://www.facebook.com/groups/376287875353461)

--- a/src/pages/meshcore.js
+++ b/src/pages/meshcore.js
@@ -114,22 +114,23 @@ export default function Home() {
                   </table>
                 </div>
               </div>
-              <div class="contact-card">
+              <div className="contact-card">
                 <h3>MeshCore Channel</h3>
                 <p><strong>MeshCore Channel:</strong></p>
-                <div class="channel-list">
-                  <code class="channel-pill">#ma-mesh</code>
-                  <code class="channel-pill">#chat</code>
-                  <code class="channel-pill">#coffee</code>
-                  <code class="channel-pill">Public</code>
-                  <code class="channel-pill">#emergency</code>
-                  <code class="channel-pill">#ice-alert</code>
-                  <code class="channel-pill">#jokes</code>
-                  <code class="channel-pill">#politics</code>
-                  <code class="channel-pill">#test</code>
-                  <code class="channel-pill">#weather</code>
+                <div className="channel-list">
+                  <code className="channel-pill">Public</code>
+                  <code className="channel-pill">#ma-mesh</code>
+                  <code className="channel-pill">#ma-hc</code>
+                  <code className="channel-pill">#chat</code>
+                  <code className="channel-pill">#coffee</code>
+                  <code className="channel-pill">#emergency</code>
+                  <code className="channel-pill">#ice-alert</code>
+                  <code className="channel-pill">#jokes</code>
+                  <code className="channel-pill">#politics</code>
+                  <code className="channel-pill">#test</code>
+                  <code className="channel-pill">#weather</code>
                 </div>
-                <p class="channel-note">Once you’re online, say hello in `#ma-mesh` so we know you’re there! Use `#test` for trying out nodes and testing paths. Ask in Discord or `Public` mesh chat for other channels in use.</p>
+                <p className="channel-note">New users can start in Public. Once your client is configured, use #ma-mesh for regional chat and #test for node/path testing. See the <a href="https://bostonme.sh/docs/MeshCore/meshcore-channels" target="_blank" rel="noopener noreferrer">MeshCore Channels</a> doc for current channel conventions.</p>
                 <p><strong>Discord Server:</strong></p>
                 <div className="channel-hash">
                   <a

--- a/src/pages/meshcore.js
+++ b/src/pages/meshcore.js
@@ -80,47 +80,48 @@ export default function Home() {
               <div className="contact-card">
                 <h3>MeshCore Radio Settings</h3>
                 <div className="radio-settings-table">
-                <table className="radio-table">
-                  <tbody>
-                    <tr>
-                      <td><strong>Preset:</strong></td>
-                      <td>USA/Canada (Recommended)</td>
-                    </tr>
-                    <tr>
-                      <td><strong>Frequency:</strong></td>
-                      <td>910.525 MHz</td>
-                    </tr>
-                    <tr>
-                      <td><strong>Bandwidth:</strong></td>
-                      <td>62.5 kHz</td>
-                    </tr>
-                    <tr>
-                      <td><strong>Spreading Factor:</strong></td>
-                      <td>7</td>
-                    </tr>
-                    <tr>
-                      <td><strong>Coding Rate:</strong></td>
-                      <td>5</td>
-                    </tr>
-                    <tr>
-                      <td><strong>Advert (Zero Hop):</strong></td>
-                      <td>12 hours</td>
-                    </tr>
-                    <tr>
-                      <td><strong>Advert (Flood):</strong></td>
-                      <td>48 hours</td>
-                    </tr>
-                  </tbody>
-                </table>
+                  <table className="radio-table">
+                    <tbody>
+                      <tr>
+                        <td><strong>Preset:</strong></td>
+                        <td>USA/Canada (Recommended)</td>
+                      </tr>
+                      <tr>
+                        <td><strong>Frequency:</strong></td>
+                        <td>910.525 MHz</td>
+                      </tr>
+                      <tr>
+                        <td><strong>Bandwidth:</strong></td>
+                        <td>62.5 kHz</td>
+                      </tr>
+                      <tr>
+                        <td><strong>Spreading Factor:</strong></td>
+                        <td>7</td>
+                      </tr>
+                      <tr>
+                        <td><strong>Coding Rate:</strong></td>
+                        <td>5</td>
+                      </tr>
+                      <tr>
+                        <td><strong>Advert (Zero Hop):</strong></td>
+                        <td>12 hours</td>
+                      </tr>
+                      <tr>
+                        <td><strong>Advert (Flood):</strong></td>
+                        <td>48 hours</td>
+                      </tr>
+                    </tbody>
+                  </table>
                 </div>
               </div>
               <div class="contact-card">
                 <h3>MeshCore Channel</h3>
                 <p><strong>MeshCore Channel:</strong></p>
                 <div class="channel-list">
-                  <code class="channel-pill">Public</code>
+                  <code class="channel-pill">#ma-mesh</code>
                   <code class="channel-pill">#chat</code>
                   <code class="channel-pill">#coffee</code>
+                  <code class="channel-pill">Public</code>
                   <code class="channel-pill">#emergency</code>
                   <code class="channel-pill">#ice-alert</code>
                   <code class="channel-pill">#jokes</code>
@@ -128,7 +129,7 @@ export default function Home() {
                   <code class="channel-pill">#test</code>
                   <code class="channel-pill">#weather</code>
                 </div>
-                <p class="channel-note">Once you’re online, say hello in Public so we know you’re there! Use #test for trying out nodes and testing paths. Ask in Discord or Public mesh chat for other channels in use.</p>
+                <p class="channel-note">Once you’re online, say hello in `#ma-mesh` so we know you’re there! Use `#test` for trying out nodes and testing paths. Ask in Discord or `Public` mesh chat for other channels in use.</p>
                 <p><strong>Discord Server:</strong></p>
                 <div className="channel-hash">
                   <a


### PR DESCRIPTION
This largely copies the announcement in discord, but adapted some for readability, clarity, and wider audience. Updates have also been made to the main landing page and other documentation.

Included as well is changing references to `meshcore.io` instead of the region-coded `meshcore.co.uk`. If those are out of scope, I can take them out :D