### PR TITLE
Add MeshCore troubleshooting guide with common issues and diagnostics

### DIFF
--- a/docs/MeshCore/meshcore-troubleshooting.md
+++ b/docs/MeshCore/meshcore-troubleshooting.md
@@ -8,8 +8,6 @@ sidebar_label: MeshCore Troubleshooting
 
 Most issues are not hardware or configuration problems - they are **antenna placement and RF environment problems**.
 
----
-
 ## A Quick Note on Expectations
 
 The Greater Boston Mesh covers various parts of Massachusetts and even has connections that cross state lines, but it is not a solid network everywhere.
@@ -18,22 +16,20 @@ LoRa has impressive range compared to technologies like Bluetooth, but it is not
 
 Getting on the mesh involves some basic understanding of radio and a bit of experimentation. You do not need to be an expert, and there are resources to help, but it is usually not as simple as buying a device and instantly connecting.
 
----
 
 ## Start Here: What are you experiencing?
 
----
 
-## I can hear others, but they can’t hear me
+### "I can hear others, but they can’t hear me"
 
 This is the most common issue.
 
-### Step 1: Confirm the problem
+#### Step 1: Confirm the problem
 - Go to: https://healthcheck.bostonme.sh/
 - Copy the code and send it to **#ma-hc**
 - Go back to https://healthcheck.bostonme.sh/ to confirm whether any observer nodes received your message
 
-### Step 2: Check basic indicators
+#### Step 2: Check basic indicators
 - When you send a message, do you see any **“repeats heard”**?
   - If yes → your message is getting out somewhere  
     - View which repeaters heard you  
@@ -41,15 +37,15 @@ This is the most common issue.
     - Check how strong the connection was
   - If no → likely a transmit or location issue
 
-### Step 3: Use the path information
+#### Step 3: Use the path information
 - In the companion UI, go to a message you have received
 - Look at the **last path before your node**
 - Try to **ping that repeater**
   - If you can’t reach it, your upstream link is weak or nonexistent
 
-### Step 4: Look at geography
-- Check the map:
-  - https://bostonme.sh/meshcore
+#### Step 4: Look at geography
+- Check the Live Map:
+  - https://live.bostonme.sh/
 - Or use the map tools in the MeshCore mobile app:
   - Map view
   - Tools → **Line of Sight** (helps evaluate paths to distant repeaters)
@@ -58,18 +54,19 @@ This is the most common issue.
   - Are there obvious obstructions?
     - Note: Line of sight tools consider terrain, but not buildings
 
-### Step 5: Check wider mesh visibility
-- Use the analyzer:
-  - https://analyzer.letsmesh.net/packets
+#### Step 5: Check wider mesh visibility
+- Use one of the analyzers:
+  - https://analyzer.letsmesh.net/packets?region=BOS
+  - https://analyzer.bostonme.sh/#/packets
 - Do your packets show up at any observers?
   - If yes → you’re getting out, even if not reliably
   - If no → your signal likely isn’t reaching the wider mesh
 
-### Step 6: Check transmit power
+#### Step 6: Check transmit power
 - Make sure your TX power matches your device capability
   - Example: if your device supports 22 dBm but is set to 10 dBm, increase it
 
-### Step 7: If none of the above helps
+#### Step 7: If none of the above helps
 At this point, it is almost always one of:
 - Antenna placement (height, obstruction)
 - Indoor vs outdoor setup
@@ -83,13 +80,13 @@ At this point, it is almost always one of:
 
 ---
 
-## I’m not hearing anything at all
+### "I’m not hearing anything at all"
 
-### Step 1: Confirm the basics
+#### Step 1: Confirm the basics
 - Make sure you are using **[MeshCore](https://bostonme.sh/docs/MeshCore/meshcore-getting-started/#flashing-and-initial-setup) (not Meshtastic)**
 - Double-check your configuration against [the getting started guide](https://bostonme.sh/docs/MeshCore/meshcore-getting-started/)
 
-### Step 2: Treat as a link issue
+#### Step 2: Treat as a link issue
 This is effectively the same root problem as above:
 - Poor antenna placement
 - No nearby nodes
@@ -102,9 +99,7 @@ This is effectively the same root problem as above:
   - Antenna setup
   - Nearby mesh presence
 
----
-
-## Messages are inconsistent or random
+## "Messages are inconsistent or random"
 
 This is almost always a **weak or marginal signal**.
 
@@ -118,9 +113,8 @@ This is almost always a **weak or marginal signal**.
 - Reposition slightly (even small moves matter)
 - Focus on establishing a **stable path to one repeater**
 
----
 
-## I only connect sometimes
+## "I only connect sometimes"
 
 Same root cause as above: **edge-of-range signal**
 
@@ -130,9 +124,7 @@ Same root cause as above: **edge-of-range signal**
 - Same steps as inconsistent messages
 - Prioritize **stability over reach**
 
----
-
-## I see activity, but nothing useful
+## "I see activity, but nothing useful"
 
 This is effectively the same as:
 
@@ -146,8 +138,6 @@ You are receiving something, but:
 - Focus on reaching a **specific nearby repeater**
 - Don’t assume “activity” = “working connection”
 
----
-
 ## Common Gotchas
 
 - Line of sight matters more than power (height helps)
@@ -158,8 +148,6 @@ You are receiving something, but:
 - A better antenna does not fix a bad location
 - “It worked once” does not mean it’s stable
 
----
-
 ## Final Advice
 
 If you’re troubleshooting:
@@ -168,7 +156,7 @@ If you’re troubleshooting:
 2. Test temporary setups before committing  
 3. Prioritize **height and placement over everything else**
 
-If you [ask for help](https://discord.gg/MUVASVEEES), include:
+If you [ask for help](https://discord.gg/MUVASVEEES) in the discord make sure to include:
 - Your hardware (radio + antenna)
 - Your location (general area is fine)
 - What you’re seeing (RSSI/SNR if available)

--- a/docs/MeshCore/meshcore-troubleshooting.md
+++ b/docs/MeshCore/meshcore-troubleshooting.md
@@ -1,0 +1,175 @@
+---
+id: meshcore-troubleshooting
+title: MeshCore Troubleshooting
+sidebar_label: MeshCore Troubleshooting
+---
+
+# MeshCore Troubleshooting Guide
+
+Most issues are not hardware or configuration problems - they are **antenna placement and RF environment problems**.
+
+---
+
+## A Quick Note on Expectations
+
+The Greater Boston Mesh covers various parts of Massachusetts and even has connections that cross state lines, but it is not a solid network everywhere.
+
+LoRa has impressive range compared to technologies like Bluetooth, but it is not going to magically provide coverage everywhere.
+
+Getting on the mesh involves some basic understanding of radio and a bit of experimentation. You do not need to be an expert, and there are resources to help, but it is usually not as simple as buying a device and instantly connecting.
+
+---
+
+## Start Here: What are you experiencing?
+
+---
+
+## I can hear others, but they can’t hear me
+
+This is the most common issue.
+
+### Step 1: Confirm the problem
+- Go to: https://healthcheck.bostonme.sh/
+- Copy the code and send it to **#ma-hc**
+- Go back to https://healthcheck.bostonme.sh/ to confirm whether any observer nodes received your message
+
+### Step 2: Check basic indicators
+- When you send a message, do you see any **“repeats heard”**?
+  - If yes → your message is getting out somewhere  
+    - View which repeaters heard you  
+    - Note: “repeats heard” means a repeater heard your message and your companion heard that repeater repeat it  
+    - Check how strong the connection was
+  - If no → likely a transmit or location issue
+
+### Step 3: Use the path information
+- In the companion UI, go to a message you have received
+- Look at the **last path before your node**
+- Try to **ping that repeater**
+  - If you can’t reach it, your upstream link is weak or nonexistent
+
+### Step 4: Look at geography
+- Check the map:
+  - https://bostonme.sh/meshcore
+- Or use the map tools in the MeshCore mobile app:
+  - Map view
+  - Tools → **Line of Sight** (helps evaluate paths to distant repeaters)
+- Questions to ask:
+  - Are there repeaters near you?
+  - Are there obvious obstructions?
+    - Note: Line of sight tools consider terrain, but not buildings
+
+### Step 5: Check wider mesh visibility
+- Use the analyzer:
+  - https://analyzer.letsmesh.net/packets
+- Do your packets show up at any observers?
+  - If yes → you’re getting out, even if not reliably
+  - If no → your signal likely isn’t reaching the wider mesh
+
+### Step 6: Check transmit power
+- Make sure your TX power matches your device capability
+  - Example: if your device supports 22 dBm but is set to 10 dBm, increase it
+
+### Step 7: If none of the above helps
+At this point, it is almost always one of:
+- Antenna placement (height, obstruction)
+- Indoor vs outdoor setup
+- Hardware limitations
+
+**Big improvement options:**
+- Move antenna higher
+- Move outdoors
+- Improve line of sight
+- Consider hosting a nearby [repeater](https://bostonme.sh/docs/MeshCore/meshcore-getting-started#repeater-infrastructure) in an elevated outdoor location
+
+---
+
+## I’m not hearing anything at all
+
+### Step 1: Confirm the basics
+- Make sure you are using **[MeshCore](https://bostonme.sh/docs/MeshCore/meshcore-getting-started/#flashing-and-initial-setup) (not Meshtastic)**
+- Double-check your configuration against [the getting started guide](https://bostonme.sh/docs/MeshCore/meshcore-getting-started/)
+
+### Step 2: Treat as a link issue
+This is effectively the same root problem as above:
+- Poor antenna placement
+- No nearby nodes
+- [Incorrect settings](https://bostonme.sh/docs/MeshCore/meshcore-getting-started/#greater-boston-mesh-conventions-and-guidance)
+
+### What to do
+- Follow the same steps as **“I can hear others, but they can’t hear me”**
+- Focus on:
+  - Location
+  - Antenna setup
+  - Nearby mesh presence
+
+---
+
+## Messages are inconsistent or random
+
+This is almost always a **weak or marginal signal**.
+
+### What’s happening
+- Your node is right at the edge of usable connectivity
+- Some packets make it through, others don’t
+
+### What to do
+- Improve antenna height
+- Reduce obstructions
+- Reposition slightly (even small moves matter)
+- Focus on establishing a **stable path to one repeater**
+
+---
+
+## I only connect sometimes
+
+Same root cause as above: **edge-of-range signal**
+
+- Time-of-day changes, interference, or minor RF shifts can push you in and out of connectivity
+
+### What to do
+- Same steps as inconsistent messages
+- Prioritize **stability over reach**
+
+---
+
+## I see activity, but nothing useful
+
+This is effectively the same as:
+
+→ **I can hear others, but they can’t hear me**
+
+You are receiving something, but:
+- It may be distant nodes
+- It may not be a usable path
+
+### What to do
+- Focus on reaching a **specific nearby repeater**
+- Don’t assume “activity” = “working connection”
+
+---
+
+## Common Gotchas
+
+- Line of sight matters more than power (height helps)
+- Indoor setups perform significantly worse than outdoor
+- Being below your roofline can block large portions of the horizon
+- You can hear a node that cannot hear you
+- A higher gain antenna can increase distance but flatten your signal pattern
+- A better antenna does not fix a bad location
+- “It worked once” does not mean it’s stable
+
+---
+
+## Final Advice
+
+If you’re troubleshooting:
+
+1. Change one thing at a time  
+2. Test temporary setups before committing  
+3. Prioritize **height and placement over everything else**
+
+If you [ask for help](https://discord.gg/MUVASVEEES), include:
+- Your hardware (radio + antenna)
+- Your location (general area is fine)
+- What you’re seeing (RSSI/SNR if available)
+- What you’ve already tried


### PR DESCRIPTION
## Summary

Adds a MeshCore troubleshooting guide to the site to help users diagnose common connectivity issues without needing to rely on Discord.

## Details
 * Organizes troubleshooting by user-reported symptoms (e.g., “can hear others but they can’t hear me”)
 * Includes step-by-step diagnostics using existing tools
 * Covers common root causes (antenna placement, RF environment, etc.)
 * Adds a short expectations section to clarify that mesh coverage is not uniform and requires some experimentation

## Goal
Reduce repetitive troubleshooting questions and give users a clear path to self-diagnose issues.

This is intended to be a starting point and can be expanded over time based on common questions and real-world scenarios.