### PR TITLE
Fix and update MeshCore resource links in documentation

### DIFF
--- a/docs/MeshCore/meshcore-getting-started.md
+++ b/docs/MeshCore/meshcore-getting-started.md
@@ -14,7 +14,7 @@ This page is intended to help you get oriented, understand your options, and fig
 
 If you are interested in hosting infrastructure for the network without getting deeply involved, you may also want to read [Host a Node](https://bostonme.sh/docs/host-a-node).
 
-If you are want to learn more about MeshCore in general please visit [MeshCore.io](https://meshcore.io/about.html).
+If you are want to learn more about MeshCore in general please visit [MeshCore.io](https://meshcore.io/).
 
 ---
 
@@ -84,7 +84,7 @@ If you’re just getting started, you can skip room servers entirely. Most peopl
 
 ## Encryption and visibility
 
-[MeshCore traffic is encrypted](https://meshcore.co.uk/about.html). However:
+MeshCore traffic is encrypted. However:
 
 - Public channels are shared keys, meaning anyone with that channel key can read those messages
 - Message routing metadata (the path a message took through the mesh) is visible to the network
@@ -129,7 +129,7 @@ If you are running a companion node in a fixed location or planning to host a re
 
 When you’re ready to set up your LoRa radio, the first step is loading **MeshCore firmware** onto the device using the official MeshCore web flasher:
 
-[MeshCore Web Flasher](https://flasher.meshcore.co.uk)
+[MeshCore Web Flasher](https://meshcore.io/flasher)
 
 Typical first-time steps:
 

--- a/docs/MeshCore/meshcore-resources.md
+++ b/docs/MeshCore/meshcore-resources.md
@@ -12,7 +12,7 @@ Here are the main links we reference most often across **Greater Boston Mesh** f
 
 The official MeshCore site and documentation are the best places to start for core guides and project updates.
 
-* **MeshCore:** https://meshcore.io/flasher
+* **MeshCore:** https://meshcore.io/
 * **GitHub Docs:** https://docs.meshcore.io/
 * **Repeater & Room Server CLI Reference:** https://github.com/meshcore-dev/MeshCore/wiki/Repeater-&-Room-Server-CLI-Reference
 

--- a/docs/MeshCore/meshcore-resources.md
+++ b/docs/MeshCore/meshcore-resources.md
@@ -12,8 +12,8 @@ Here are the main links we reference most often across **Greater Boston Mesh** f
 
 The official MeshCore site and documentation are the best places to start for core guides and project updates.
 
-* **MeshCore:** https://meshcore.dev/
-* **GitHub Docs:** https://github.com/meshcore-dev/MeshCore/tree/main/docs
+* **MeshCore:** https://meshcore.io/flasher
+* **GitHub Docs:** https://docs.meshcore.io/
 * **Repeater & Room Server CLI Reference:** https://github.com/meshcore-dev/MeshCore/wiki/Repeater-&-Room-Server-CLI-Reference
 
 Start there for installation steps, configuration details, and CLI usage before exploring community tools or custom builds.
@@ -24,7 +24,7 @@ Start there for installation steps, configuration details, and CLI usage before 
 
 This is where you’ll find the **officialMeshCore firmware** and the easiest way to flash it onto supported hardware. It’s typically the fastest path from “new board” to “on the air.”
 
-- MeshCore Flasher: https://flasher.meshcore.dev/
+- MeshCore Flasher: https://meshcore.io/flasher
 
 ### Easy SkyMesh Custom Firmware
 

--- a/docs/community-spaces.md
+++ b/docs/community-spaces.md
@@ -19,6 +19,6 @@ You may also find these regional communities helpful:
 
 ## Official Discords
 
-- [Official MeshCore Discord](https://discord.gg/bSuST8xvet)
+- [Official MeshCore.io Discord](https://meshcore.gg/)
 - [Official Meshtastic Discord](https://discord.gg/meshtastic) | [Massachusetts Area Chat](https://discord.com/channels/867578229534359593/1201546802437042286)
 - [Official MeshMapper Discord](https://discord.gg/WdAeFKRne)

--- a/src/pages/meshcore.js
+++ b/src/pages/meshcore.js
@@ -52,7 +52,7 @@ export default function Home() {
             <h2>What is MeshCore?</h2>
             <div className="about-description">
               <p>MeshCore is a multi-platform system for enabling secure text-based communications utilizing LoRa radio hardware. It can be used for Off-Grid Communication, Emergency Response & Disaster Recovery, Outdoor Activities, Tactical Security including law enforcement, private security and also IoT sensor networks.</p>
-              <p><a href="https://meshcore.co.uk/" target="_blank" rel="noopener">Learn more about MeshCore →</a></p>
+              <p><a href="https://meshcore.io/" target="_blank" rel="noopener">Learn more about MeshCore →</a></p>
             </div>
           </div>
         </section>


### PR DESCRIPTION
Replaced all meshcore links to point to https://meshcore.io/ and not https://meshcore.co.uk/